### PR TITLE
docs: add investigation playbook for ClickHouse + ZooKeeper

### DIFF
--- a/INVESTIGATION_PLAYBOOK.md
+++ b/INVESTIGATION_PLAYBOOK.md
@@ -1,0 +1,205 @@
+# Investigation Playbook: ClickHouse + ZooKeeper
+
+A methodology for diagnosing replication, ZooKeeper/Keeper, and counter-anomaly issues using the read-only system tables exposed via this MCP server.
+
+Written from lessons learned during real production investigations. The goal is to avoid common dead ends — particularly the trap of "the source code says X but the data shows Y, so it must be a bug."
+
+## Core principle
+
+> When source code seems to contradict observed data, the workload is almost certainly using a code path you haven't traced yet. Map the workload before forming a hypothesis.
+
+The single biggest time-saver is enumerating *what operations actually touch the relevant tables* before forming a theory about *why* a counter or metric is moving.
+
+## Standard first-pass triage
+
+When investigating any counter spike, error pattern, or replication anomaly on a Replicated table, run these queries in order. Each one narrows the hypothesis space.
+
+### 1. What workload touches the table?
+
+```sql
+-- All DDL + structural ALTERs on the table in the last hour
+SELECT
+    event_time, hostName() AS host, query_kind,
+    substring(query, 1, 200) AS query
+FROM clusterAllReplicas('<cluster>', system.query_log)
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND type = 'QueryFinish'
+  AND query ILIKE '%<table_name>%'
+  AND query_kind IN ('Create', 'Drop', 'Alter', 'Truncate', 'Rename', 'System')
+ORDER BY event_time DESC
+LIMIT 50;
+```
+
+`CREATE OR REPLACE TABLE`, `DROP TABLE`, `TRUNCATE`, `ALTER … REPLACE PARTITION`, `ATTACH PARTITION`, and `RESTART REPLICA` all have very different effects on replication state — and they all show up here.
+
+### 2. Is the issue ensemble-wide or single-node?
+
+```sql
+-- Count error events per host in last hour
+SELECT
+    hostName() AS host, name, value, last_error_time,
+    substring(last_error_message, 1, 200) AS msg
+FROM clusterAllReplicas('<cluster>', system.errors)
+WHERE value > 0
+  AND last_error_time > now() - INTERVAL 1 HOUR
+ORDER BY last_error_time DESC
+LIMIT 50;
+```
+
+Single-host bursts usually mean local saturation (query queue, disk, network). Cluster-wide bursts mean ZK ensemble or shared infrastructure.
+
+### 3. Is the table actually readonly?
+
+```sql
+-- Both gauge (right-now) and historical (last hour)
+SELECT
+    hostName() AS host,
+    event_time,
+    CurrentMetric_ReadonlyReplica AS readonly_count
+FROM clusterAllReplicas('<cluster>', system.metric_log)
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND CurrentMetric_ReadonlyReplica > 0
+ORDER BY event_time DESC
+LIMIT 50;
+```
+
+`CurrentMetric_ReadonlyReplica > 0` is the most reliable indicator of a real replication problem. If this is zero throughout an incident, the table was never actually impaired — even if other counters were ticking.
+
+### 4. Did any ZooKeeper session actually expire?
+
+```sql
+-- Authoritative log for real session-expiry events
+SELECT
+    hostName() AS host, event_time,
+    extract(logger_name, '\((.+?)\)') AS thread,
+    logger_name,
+    substring(message, 1, 200) AS msg
+FROM clusterAllReplicas('<cluster>', system.text_log)
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND message ILIKE '%ZooKeeper session has expired%'
+ORDER BY event_time DESC
+LIMIT 50;
+```
+
+The `LOG_WARNING "ZooKeeper session has expired. Switching to a new session."` line from `ReplicatedMergeTreeRestartingThread` is emitted *exactly once per session-expiry event per table* on the affected host. If a node's ZK session truly expired, you will see one line per Replicated table on that host (often dozens to hundreds of identical lines clustered in a 1-second window).
+
+## Counter pitfalls
+
+Some `ProfileEvent_*` counters are easy to misread. Two common ones:
+
+### `ReplicaPartialShutdown`
+
+**Documentation says**: "How many times Replicated table has to deinitialize its state due to session expiration in ZooKeeper."
+
+**Reality**: incremented in `StorageReplicatedMergeTree::partialShutdown()`, which is called both for genuine ZK session expiry **and** for the table's full-shutdown path. So this counter ticks on:
+
+- Real ZK session expiration (with `LOG_WARNING`, readonly tick, ~N ticks per host where N = number of Replicated tables on that host)
+- `DROP TABLE` / `DETACH TABLE` / `RENAME` / **`CREATE OR REPLACE TABLE`**
+- Server shutdown / table flush-prepare
+
+The full-shutdown path does **not** produce a `LOG_WARNING`, does **not** tick `CurrentMetric_ReadonlyReplica`, and only affects the one table being shut down.
+
+So if you see this counter incrementing with no session-expiry log line and no readonly metric, look for `CREATE OR REPLACE TABLE` or similar DDL on the affected tables — it's likely a workload pattern, not a problem.
+
+### `metric_log.ProfileEvent_*` semantics
+
+The columns in `system.metric_log` are **per-second deltas** of the global counter, not the cumulative value. Verify with a known-rate counter:
+
+```sql
+-- Should roughly match: total Query counter delta vs query_log count
+SELECT sum(ProfileEvent_Query) AS metric_log_delta
+FROM system.metric_log
+WHERE event_time > now() - INTERVAL 10 MINUTE;
+
+SELECT count() AS query_log_total
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 10 MINUTE AND type = 'QueryStart';
+```
+
+If they don't match, your understanding of the column is wrong.
+
+## Decision tree: counter incrementing with no obvious cause
+
+```
+Counter is incrementing every X minutes
+│
+├─ All hosts simultaneously?
+│  ├─ Yes → workload-driven (DDL ON CLUSTER, scheduled job, replication broadcast)
+│  │       → Query system.query_log for that table; check for Create/Drop/Alter at the burst times
+│  │
+│  └─ No (one host or subset) → host-local cause
+│           → Check system.errors per host (saturation, disk, network)
+│           → Check system.text_log for that host (session expiry, hardware errors)
+│
+├─ Does the side-effect signature match?
+│  ├─ readonly tick + log line + N-table cascade → real session expiry
+│  ├─ readonly tick + no log line + just this one table → table-level startup failure
+│  └─ no readonly tick + no log line + just this one table → likely full-shutdown path (DDL)
+│
+└─ When source code "rules out" the observed pattern
+   → You're looking at the wrong path. Re-grep with the full set of callers.
+   → Or the workload is exercising a path not described in the counter's docs.
+```
+
+## When CH system tables aren't enough
+
+Some questions cannot be answered from `system.*`:
+
+- **What ZK transactions actually executed?** Use `zkTxnLogToolkit.sh` on the ZK ensemble against `/var/lib/zookeeper/version-2/log.*` (path varies). Pipe through `grep -a` since data values are binary.
+- **What did the ZK server log say?** `/var/log/zookeeper/*.out` or `*.log` on each ensemble node, depending on logback config. Note default INFO level filters out routine client requests.
+- **Is the ephemeral `is_active` znode for a replica being deleted and recreated?** Query `system.zookeeper` with the path from `system.replicas.replica_path` + `/is_active`. Check `ctime` and `ephemeralOwner` (session ID): if both are stable over many counter ticks, partialShutdown is not running on *that* table.
+
+### Critical: which table to inspect
+
+When a workload uses staging tables that get dropped/recreated (a common pattern for `REPLACE PARTITION` jobs), the counter ticks come from the *staging* table being shut down. Inspecting the *persistent* target table's `is_active` will mislead you — it never changes. Always cross-reference `system.query_log` to find which table(s) the workload actually creates/drops.
+
+## Productive query patterns
+
+### Find which tables a ZK session ID belongs to
+
+```sql
+SELECT zookeeper_path, replica_path, replica_name
+FROM clusterAllReplicas('<cluster>', system.replicas)
+WHERE database = '<db>';
+```
+
+Then walk `system.zookeeper` from `zookeeper_path` to find children and ephemeralOwners.
+
+### Correlate counter bursts with DDL
+
+```sql
+-- Per-host counter increments (last 1h)
+SELECT event_time, hostName() AS host, ProfileEvent_<NAME> AS tick
+FROM clusterAllReplicas('<cluster>', system.metric_log)
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND ProfileEvent_<NAME> > 0
+ORDER BY event_time;
+
+-- DDL on potentially-related tables, same window
+SELECT event_time, hostName() AS host, query_kind, substring(query, 1, 150) AS q
+FROM clusterAllReplicas('<cluster>', system.query_log)
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND type = 'QueryFinish'
+  AND query_kind IN ('Create', 'Drop', 'Alter')
+ORDER BY event_time;
+```
+
+A 100% temporal correlation between bursts and a specific DDL pattern is usually the answer.
+
+## Alerting recommendations
+
+Based on signal quality observed in real investigations:
+
+- **High signal**: `text_log` matches for `"ZooKeeper session has expired"` — fires on genuine session loss, near-zero false positives.
+- **High signal**: `CurrentMetric_ReadonlyReplica > 0` — direct gauge for table impairment.
+- **Lower signal**: `ProfileEvent_ReplicaPartialShutdown` — increments on DDL too; use only with a per-host rate threshold high enough to filter out normal DDL noise (e.g. `>5 per host per 5min`).
+
+## Reasoning hygiene
+
+Habits that prevent misadventures:
+
+1. **Map the workload before forming hypotheses.** `system.query_log` GROUP BY query_kind on suspect tables is almost always query #1.
+2. **Verify column semantics with a known-rate counter** before reasoning about an unfamiliar metric.
+3. **Treat "source says impossible" as a signal to widen the source grep**, not to escalate to "must be a bug."
+4. **Check the right table.** If a workload uses ephemeral / staging / `_tmp_*` tables, the persistent target tables can look untouched while the action is happening on tables you didn't initially list.
+5. **State explicit predictions before each query.** "If this is X, I expect Y rows. If it's Z, I expect 0." Forces you to notice when the data falsifies your model, instead of rationalizing it.

--- a/MCP.md
+++ b/MCP.md
@@ -4,6 +4,8 @@
 1. Read‑only queries against configurable ClickHouse databases
 2. Querying Prometheus metrics for monitoring and correlation
 
+> **Looking for investigation guidance?** See [INVESTIGATION_PLAYBOOK.md](./INVESTIGATION_PLAYBOOK.md) for a methodology and `system.*` query patterns for diagnosing ClickHouse + ZooKeeper issues using these tools.
+
 ## Installation
 
 ### Option 1: Install via go install (Recommended)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Example requests:
 
 ---
 
+## 🔍 Investigation Playbook
+
+For diagnosing ClickHouse + ZooKeeper issues (replication anomalies, counter spikes, session expirations, readonly replicas) using the MCP tools above, see **[INVESTIGATION_PLAYBOOK.md](./INVESTIGATION_PLAYBOOK.md)**.
+
+It captures a triage methodology and a set of `system.*` query patterns that resolve most common dead ends — particularly the "source code says impossible but data shows otherwise" trap.
+
+---
+
 ## 🐳 Running with Docker
 
 ```bash

--- a/agent.go
+++ b/agent.go
@@ -70,7 +70,7 @@ func QuerySystemTable(ctx context.Context, conn driver.Conn, args QuerySystemTab
 		query.WriteString("*")
 	}
 
-	query.WriteString(fmt.Sprintf(" FROM clusterAllReplicas(%s, %s)", cluster, args.Table))
+	fmt.Fprintf(&query, " FROM clusterAllReplicas(%s, %s)", cluster, args.Table)
 
 	if args.Where != "" {
 		query.WriteString(" WHERE " + args.Where)
@@ -81,14 +81,18 @@ func QuerySystemTable(ctx context.Context, conn driver.Conn, args QuerySystemTab
 	}
 
 	if args.Limit > 0 {
-		query.WriteString(fmt.Sprintf(" LIMIT %d", args.Limit))
+		fmt.Fprintf(&query, " LIMIT %d", args.Limit)
 	}
 
 	rows, err := conn.Query(ctx, query.String())
 	if err != nil {
 		return nil, fmt.Errorf("query error: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			logrus.WithError(err).Warn("Error closing rows")
+		}
+	}()
 
 	columns := rows.Columns()
 	columnTypes := rows.ColumnTypes()
@@ -189,7 +193,11 @@ func AnalyzeErrorsWithAgent(chErrors CHErrors) string {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error connecting to ClickHouse for analysis")
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			logrus.WithError(err).Warn("Error closing ClickHouse connection")
+		}
+	}()
 
 	systemPrompt := `You are a ClickHouse database administrator analyzing system errors.
 You have access to query any ClickHouse system table to gather more context about errors.
@@ -335,7 +343,11 @@ func AnalyzeQueryPerformanceWithAgent() string {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error connecting to ClickHouse for analysis")
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			logrus.WithError(err).Warn("Error closing ClickHouse connection")
+		}
+	}()
 
 	systemPrompt := `You are a ClickHouse database performance analyst specializing in query optimization.
 You have access to query any ClickHouse system table to analyze query performance and identify optimization opportunities.

--- a/clickhouse_mcp.go
+++ b/clickhouse_mcp.go
@@ -82,7 +82,7 @@ func runClickhouseQuery(a queryArgs) ([]map[string]interface{}, error) {
 			cluster := viper.GetString("clickhouse.cluster")
 			fmt.Fprintf(&sb, " FROM clusterAllReplicas(%s, %s)", cluster, a.Table)
 		} else {
-			sb.WriteString(fmt.Sprintf(" FROM %s", a.Table))
+			fmt.Fprintf(&sb, " FROM %s", a.Table)
 		}
 		
 		if a.Where != "" {
@@ -94,7 +94,7 @@ func runClickhouseQuery(a queryArgs) ([]map[string]interface{}, error) {
 			sb.WriteString(a.OrderBy)
 		}
 		if a.Limit > 0 {
-			sb.WriteString(fmt.Sprintf(" LIMIT %d", a.Limit))
+			fmt.Fprintf(&sb, " LIMIT %d", a.Limit)
 		}
 		query = sb.String()
 	}

--- a/clickhouse_mcp.go
+++ b/clickhouse_mcp.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -58,7 +59,11 @@ func runClickhouseQuery(a queryArgs) ([]map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			logrus.WithError(err).Warn("Error closing ClickHouse connection")
+		}
+	}()
 
 	var query string
 	if strings.TrimSpace(a.SQL) != "" {
@@ -75,7 +80,7 @@ func runClickhouseQuery(a queryArgs) ([]map[string]interface{}, error) {
 		// Only use clusterAllReplicas for system tables
 		if strings.HasPrefix(strings.ToLower(a.Table), "system.") {
 			cluster := viper.GetString("clickhouse.cluster")
-			sb.WriteString(fmt.Sprintf(" FROM clusterAllReplicas(%s, %s)", cluster, a.Table))
+			fmt.Fprintf(&sb, " FROM clusterAllReplicas(%s, %s)", cluster, a.Table)
 		} else {
 			sb.WriteString(fmt.Sprintf(" FROM %s", a.Table))
 		}
@@ -99,7 +104,11 @@ func runClickhouseQuery(a queryArgs) ([]map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			logrus.WithError(err).Warn("Error closing rows")
+		}
+	}()
 
 	cols := rows.Columns()
 	colTypes := rows.ColumnTypes()
@@ -220,7 +229,7 @@ func validateFreeformSQL(sql string) error {
 	// Strip simple quoted strings to avoid false positives when scanning tokens
 	sanitized := stripQuotedLiterals(s)
 	lower := strings.ToLower(strings.TrimSpace(sanitized))
-	if !(strings.HasPrefix(lower, "select ") || strings.HasPrefix(lower, "with ")) {
+	if !strings.HasPrefix(lower, "select ") && !strings.HasPrefix(lower, "with ") {
 		return fmt.Errorf("only SELECT/WITH queries are allowed")
 	}
 	// Disallow obvious write/DDL keywords

--- a/clickhouse_mcp_test.go
+++ b/clickhouse_mcp_test.go
@@ -467,7 +467,7 @@ func TestQueryBuilding(t *testing.T) {
 				sb.WriteString(tt.args.Where)
 			}
 			if tt.args.Limit > 0 {
-				sb.WriteString(fmt.Sprintf(" LIMIT %d", tt.args.Limit))
+				fmt.Fprintf(&sb, " LIMIT %d", tt.args.Limit)
 			}
 			
 			query := sb.String()

--- a/slack.go
+++ b/slack.go
@@ -84,7 +84,11 @@ func SendSlackMessage(summary string, errorCount int) error {
 	if err != nil {
 		return fmt.Errorf("error sending slack message: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("error closing slack response body: %v", err)
+		}
+	}()
 
 	body, _ := io.ReadAll(resp.Body)
 


### PR DESCRIPTION
## Summary

- Adds `INVESTIGATION_PLAYBOOK.md` — a methodology + reusable `system.*` query patterns for diagnosing replication and ZooKeeper issues using housekeeper's MCP tools
- Documents a real pitfall: `ProfileEvent_ReplicaPartialShutdown` increments on full-shutdown paths (e.g. `CREATE OR REPLACE TABLE` on a Replicated staging table), not just on the ZK session expiry the metric description suggests
- Linked from `README.md` and `MCP.md` so it's discoverable from both the user-facing and tool-reference docs

## Motivation

Written from lessons learned during an investigation where misreading the `ReplicaPartialShutdown` counter sent the investigation down a dead end ("source code says this is impossible but data shows otherwise"). The playbook codifies the queries that would have caught the root cause in the first pass:

1. Map the workload before forming hypotheses (`system.query_log` GROUP BY query_kind)
2. Verify column semantics with a known-rate counter
3. When source code seems to contradict data, widen the source grep rather than escalating to "must be a bug"
4. When investigating staging/ephemeral tables, don't inspect the persistent target table's znodes

## Test plan

- [ ] Render `INVESTIGATION_PLAYBOOK.md` on GitHub — formatting is correct (tables, code fences, decision tree ASCII)
- [ ] Relative links in `README.md` and `MCP.md` resolve to the playbook
- [ ] Skim the query examples for correctness against latest ClickHouse `system.*` schemas (queries use only documented columns: `event_time`, `hostName()`, `ProfileEvent_*`, `CurrentMetric_*`, `query_kind`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
