### PR TITLE
chore: tidy config layout and auth docs/logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ go.work.sum
 # .vscode/
 
 configs/config.yml
+# Env-specific configs — only the *.yml.example templates are committed.
+configs/config-*.yml
+!configs/config-*.yml.example
 __debug*
 docker/
 .claude/

--- a/README.md
+++ b/README.md
@@ -196,10 +196,9 @@ clickhouse:
 
 ## 🔒 Security Notes
 
-- **Read-Only Access**: MCP server enforces read-only queries to configured databases
-- **No DDL Operations**: Write operations and DDL statements are blocked
-- **Bearer Auth**: Protect the HTTP endpoint with `--http-auth-token` in production
-- **Credential Safety**: Never commit `configs/config.yml` (it's in `.gitignore`)
+- **Read-Only**: SELECT-only at the SQL layer; DDL and writes are blocked. Server-side role/profile is the real boundary.
+- **Authentication**: Set `--http-auth-token` (or `HOUSEKEEPER_HTTP_AUTH_TOKEN`) for bearer auth, or leave unset and front housekeeper with a network-level identity gate.
+- **Credentials**: `configs/config*.yml` are gitignored. Only `*.example`/`*.sample` templates are tracked.
 
 ---
 

--- a/configs/config-dev.yml.example
+++ b/configs/config-dev.yml.example
@@ -1,0 +1,55 @@
+# Template for a local housekeeper instance.
+# Copy to configs/config-<env>.yml and fill in the placeholders; the real
+# files (configs/config-*.yml) are gitignored. Run with:
+#   ./housekeeper --config configs/config-<env>.yml
+
+logging:
+  level: "info"
+  format: "text"   # "text" is friendlier in a terminal; "json" for production
+
+clickhouse:
+  host: "<ch-host-fqdn>"
+  port: 9440
+  secure: true
+
+  # Connection user. Prefer a read-only user with a narrow role/profile —
+  # server-side grants are the real boundary; the MCP only enforces
+  # SELECT-only at the SQL layer.
+  user: "<read-only-user>"
+  # password injected via HOUSEKEEPER_CLICKHOUSE_PASSWORD env var
+
+  # Default database used for unqualified table references.
+  database: "<your-database>"
+
+  # Cluster name passed to clusterAllReplicas(<cluster>, system.<table>) when
+  # the MCP auto-wraps system.* queries. Must match a cluster in the server's
+  # remote_servers config.
+  cluster: "<cluster-name>"
+
+  # Databases the MCP is allowed to query. Other databases are rejected by
+  # the SQL validator regardless of the connection user's grants.
+  allowed_databases:
+    - "system"
+    - "default"
+    - "<your-database>"
+
+# Optional — only needed if you use the prometheus_query MCP tool.
+# Works with vanilla Prometheus or VictoriaMetrics (single-node or cluster).
+# prometheus:
+#   host: "localhost"
+#   port: 8481
+#   vm_cluster_mode: false   # true for VictoriaMetrics cluster mode
+#   vm_tenant_id: "0"        # only used when vm_cluster_mode is true
+#   vm_path_prefix: ""       # e.g. "prometheus" for VM cluster mode
+
+http:
+  addr: ":8080"
+  # Bearer token clients must present. Leave empty to disable bearer auth
+  # and rely on a network-level identity gate (firewall, VPN, Tailscale,
+  # authenticating proxy, or localhost binding). See README "Security Notes".
+  auth_token: ""
+
+# Optional — only used in --analyze mode (not the HTTP MCP server).
+# gemini_key: "..."
+# slack:
+#   webhook_url: "..."

--- a/sdk_mcp.go
+++ b/sdk_mcp.go
@@ -151,10 +151,10 @@ func runHTTPMCPServer(srv *mcp.Server) error {
 
 	if authToken != "" {
 		mux.Handle("/", bearerAuthMiddleware(authToken, streamHandler))
-		logrus.Info("HTTP authentication enabled")
+		logrus.Info("HTTP authentication enabled (bearer token)")
 	} else {
 		mux.Handle("/", streamHandler)
-		logrus.Warn("HTTP authentication is disabled — consider setting http.auth_token")
+		logrus.Info("HTTP authentication disabled (no auth_token configured)")
 	}
 
 	// Wrap everything with CORS + request logging.


### PR DESCRIPTION
## Summary

Tidies up the config story and the auth model docs/logs. No behavior change beyond a log-level swap.

## Changes

- **`.gitignore`** — ignore `configs/config-*.yml` so env-specific configs don't get committed; keep `*.yml.example` templates tracked.
- **`configs/config-dev.yml.example`** — generic template engineers can copy to bootstrap a local config. Covers ClickHouse, optional Prometheus (single-node or VictoriaMetrics cluster), optional bearer auth, and optional `--analyze` mode fields.
- **`README.md`** — condense Security Notes to three bullets. Describes the two valid auth models (bearer token via `--http-auth-token`, or leaving it unset and fronting with a network-level identity gate) without prescribing a specific deployment shape.
- **`sdk_mcp.go`** — downgrade "HTTP authentication disabled" log from `WARN` to `INFO`. Unset `auth_token` is a valid choice when network-level identity is provided externally; a `WARN` on every pod startup is noise.

## Testing

Built locally; log line change verified by running the binary with and without `auth_token` set. No code-path change beyond the string.
