### PR TITLE
feat(mcp): reject future timestamps, stringify big ints, optional dua…

### DIFF
--- a/clickhouse_mcp.go
+++ b/clickhouse_mcp.go
@@ -4,12 +4,18 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
+
+// maxSafeJSONInt = 2^53-1; integers beyond this lose precision in JSON's
+// double-precision representation, breaking round-trip filtering on IDs like
+// normalized_query_hash.
+const maxSafeJSONInt = 1<<53 - 1
 
 // JSON-RPC transport types
 type queryArgs struct {
@@ -166,9 +172,17 @@ func normalizeValue(v interface{}) interface{} {
 	case bool:
 		return t
 	case int, int8, int16, int32, int64:
-		return reflect.ValueOf(t).Int()
+		i := reflect.ValueOf(t).Int()
+		if i > maxSafeJSONInt || i < -maxSafeJSONInt {
+			return strconv.FormatInt(i, 10)
+		}
+		return i
 	case uint, uint8, uint16, uint32, uint64:
-		return reflect.ValueOf(t).Uint()
+		u := reflect.ValueOf(t).Uint()
+		if u > maxSafeJSONInt {
+			return strconv.FormatUint(u, 10)
+		}
+		return u
 	case float32, float64:
 		return reflect.ValueOf(t).Float()
 	case time.Time:

--- a/config.go
+++ b/config.go
@@ -34,6 +34,13 @@ func loadConfig(explicitPath string) error {
 	viper.SetDefault("prometheus.vm_cluster_mode", false)
 	viper.SetDefault("prometheus.vm_tenant_id", "0")
 	viper.SetDefault("prometheus.vm_path_prefix", "")
+
+	// Optional second endpoint for ClickHouse-internal metrics. Empty host disables it.
+	viper.SetDefault("prometheus_clickhouse.host", "")
+	viper.SetDefault("prometheus_clickhouse.port", 9091)
+	viper.SetDefault("prometheus_clickhouse.vm_cluster_mode", false)
+	viper.SetDefault("prometheus_clickhouse.vm_tenant_id", "0")
+	viper.SetDefault("prometheus_clickhouse.vm_path_prefix", "")
 	
 	viper.SetDefault("logging.level", "info")
 	viper.SetDefault("logging.format", "text")

--- a/prometheus_mcp.go
+++ b/prometheus_mcp.go
@@ -12,63 +12,84 @@ import (
 	"github.com/spf13/viper"
 )
 
-var promClient v1.API
+const (
+	defaultPromEndpoint = "default"
+	chPromEndpoint      = "clickhouse"
+)
 
-// prometheusArgs defines the arguments for Prometheus queries
+// promClients are keyed by endpoint name. Default is always present;
+// `clickhouse` is opt-in via prometheus_clickhouse.host.
+var promClients = map[string]v1.API{}
+
+// prometheusArgs defines the arguments for Prometheus queries.
 type prometheusArgs struct {
 	Query string `json:"query"`           // PromQL query string
-	Start string `json:"start,omitempty"` // Start time in RFC3339 format
-	End   string `json:"end,omitempty"`   // End time in RFC3339 format
+	Start string `json:"start,omitempty"` // Start time in RFC3339 format or relative ("-30m")
+	End   string `json:"end,omitempty"`   // End time in RFC3339 format or relative; defaults to now()
 	Step  string `json:"step,omitempty"`  // Step duration (e.g. "15s", "1m", "1h")
 }
 
-func initPrometheus() error {
-	baseURL := fmt.Sprintf("http://%s:%d",
-		viper.GetString("prometheus.host"),
-		viper.GetInt("prometheus.port"),
-	)
+func buildPromBaseURL(configKey string) string {
+	host := viper.GetString(configKey + ".host")
+	port := viper.GetInt(configKey + ".port")
+	baseURL := fmt.Sprintf("http://%s:%d", host, port)
 
-	// Handle VictoriaMetrics cluster mode
-	if viper.GetBool("prometheus.vm_cluster_mode") {
-		tenantID := viper.GetString("prometheus.vm_tenant_id")
-		pathPrefix := viper.GetString("prometheus.vm_path_prefix")
+	if viper.GetBool(configKey + ".vm_cluster_mode") {
+		tenantID := viper.GetString(configKey + ".vm_tenant_id")
+		pathPrefix := viper.GetString(configKey + ".vm_path_prefix")
 		if pathPrefix == "" {
 			pathPrefix = "prometheus"
 		}
 		baseURL = fmt.Sprintf("%s/select/%s/%s", baseURL, tenantID, pathPrefix)
 	}
+	return baseURL
+}
 
-	cfg := api.Config{
-		Address: baseURL,
-	}
-
+func initPromClient(configKey string) (v1.API, error) {
+	cfg := api.Config{Address: buildPromBaseURL(configKey)}
 	client, err := api.NewClient(cfg)
 	if err != nil {
-		return fmt.Errorf("error creating prometheus client: %v", err)
+		return nil, fmt.Errorf("error creating prometheus client for %q: %v", configKey, err)
 	}
+	return v1.NewAPI(client), nil
+}
 
-	promClient = v1.NewAPI(client)
+func initPrometheus() error {
+	defaultClient, err := initPromClient("prometheus")
+	if err != nil {
+		return err
+	}
+	promClients[defaultPromEndpoint] = defaultClient
+
+	chHost := viper.GetString("prometheus_clickhouse.host")
+	if chHost != "" && chHost != "localhost" {
+		chClient, err := initPromClient("prometheus_clickhouse")
+		if err != nil {
+			return err
+		}
+		promClients[chPromEndpoint] = chClient
+	}
 	return nil
 }
 
-// queryPrometheus executes a PromQL query and returns the results
-func queryPrometheus(query string, start, end time.Time, step time.Duration) (interface{}, error) {
-	if promClient == nil {
-		return nil, fmt.Errorf("prometheus client not initialized")
+func hasClickhousePromEndpoint() bool {
+	_, ok := promClients[chPromEndpoint]
+	return ok
+}
+
+func queryPrometheus(endpoint, query string, start, end time.Time, step time.Duration) (interface{}, error) {
+	client, ok := promClients[endpoint]
+	if !ok {
+		return nil, fmt.Errorf("prometheus endpoint %q not configured", endpoint)
 	}
 
 	ctx := context.Background()
-	r := v1.Range{
-		Start: start,
-		End:   end,
-		Step:  step,
-	}
+	r := v1.Range{Start: start, End: end, Step: step}
 
-	result, _, err := promClient.QueryRange(ctx, query, r)
+	result, _, err := client.QueryRange(ctx, query, r)
 	if err != nil {
-		return nil, fmt.Errorf("error querying prometheus: %v", err)
+		return nil, fmt.Errorf("error querying prometheus (%s): %v", endpoint, err)
 	}
-
 	return summarizePromResult(result)
 }
 
@@ -84,6 +105,26 @@ func validateAndParseTimeRange(start, end string) (time.Time, time.Time, error) 
 		if err != nil {
 			return time.Time{}, time.Time{}, fmt.Errorf("invalid end time format: %v", err)
 		}
+	}
+
+	// Reject future ranges: Prometheus silently returns empty for them, which
+	// is indistinguishable from missing data. 30s skew tolerance for clients
+	// whose clocks are slightly ahead.
+	now := time.Now().UTC()
+	const futureSkewTolerance = 30 * time.Second
+	if parsed_start.After(now.Add(futureSkewTolerance)) {
+		return time.Time{}, time.Time{}, fmt.Errorf(
+			"start time %s is in the future; current UTC is %s",
+			parsed_start.UTC().Format(time.RFC3339),
+			now.Format(time.RFC3339),
+		)
+	}
+	if parsed_end.After(now.Add(futureSkewTolerance)) {
+		return time.Time{}, time.Time{}, fmt.Errorf(
+			"end time %s is in the future; current UTC is %s",
+			parsed_end.UTC().Format(time.RFC3339),
+			now.Format(time.RFC3339),
+		)
 	}
 
 	if parsed_start.After(parsed_end) {

--- a/prometheus_mcp_test.go
+++ b/prometheus_mcp_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateAndParseTimeRange_RejectsFutureStart(t *testing.T) {
+	future := time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
+	_, _, err := validateAndParseTimeRange(future, "")
+	if err == nil {
+		t.Fatal("expected error for future start time, got nil")
+	}
+	if !strings.Contains(err.Error(), "future") {
+		t.Errorf("expected error to mention 'future', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "current UTC is") {
+		t.Errorf("expected error to surface current UTC, got: %v", err)
+	}
+}
+
+func TestValidateAndParseTimeRange_RejectsFutureEnd(t *testing.T) {
+	start := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	end := time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
+	_, _, err := validateAndParseTimeRange(start, end)
+	if err == nil {
+		t.Fatal("expected error for future end time, got nil")
+	}
+	if !strings.Contains(err.Error(), "future") {
+		t.Errorf("expected error to mention 'future', got: %v", err)
+	}
+}
+
+func TestValidateAndParseTimeRange_AllowsSmallClockSkew(t *testing.T) {
+	// 5 seconds in the future should be tolerated (within the 30s skew window)
+	nearFuture := time.Now().UTC().Add(5 * time.Second).Format(time.RFC3339)
+	_, _, err := validateAndParseTimeRange("-1h", nearFuture)
+	if err != nil {
+		t.Errorf("expected small clock-skew to be tolerated, got: %v", err)
+	}
+}
+
+func TestValidateAndParseTimeRange_AcceptsPastRange(t *testing.T) {
+	start := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	end := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	_, _, err := validateAndParseTimeRange(start, end)
+	if err != nil {
+		t.Errorf("expected past range to be accepted, got: %v", err)
+	}
+}
+
+func TestValidateAndParseTimeRange_AcceptsRelativeStart(t *testing.T) {
+	_, _, err := validateAndParseTimeRange("-30m", "")
+	if err != nil {
+		t.Errorf("expected relative start to be accepted, got: %v", err)
+	}
+}
+
+func TestValidateAndParseTimeRange_RejectsStartAfterEnd(t *testing.T) {
+	start := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	end := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	_, _, err := validateAndParseTimeRange(start, end)
+	if err == nil {
+		t.Fatal("expected error for start > end, got nil")
+	}
+	if !strings.Contains(err.Error(), "before") {
+		t.Errorf("expected error to mention ordering, got: %v", err)
+	}
+}

--- a/sdk_mcp.go
+++ b/sdk_mcp.go
@@ -83,13 +83,35 @@ Investigation tips:
 		},
 	)
 
-	// Register Prometheus tool
+	defaultPromDesc := `Execute PromQL range queries against Prometheus metrics.
+
+start/end: RFC3339 UTC or relative ("-30m", "-1h"). end defaults to now(). Future timestamps are rejected. Prefer relative ("-30m") when the current time isn't known.
+step: Go duration ("30s", "1m"). Pick one that yields <~50 points over the window.`
+	if hasClickhousePromEndpoint() {
+		defaultPromDesc += "\n\nFor ClickHouse-internal metrics (ClickHouseMetrics_*, ClickHouseProfileEvents_*, ClickHouseAsyncMetrics_*) prefer prometheus_query_clickhouse — it hits a dedicated endpoint with higher scrape resolution."
+	}
+	registerPrometheusTool(srv, "prometheus_query", "Query Prometheus metrics", defaultPromDesc, defaultPromEndpoint)
+
+	if hasClickhousePromEndpoint() {
+		chDesc := `Execute PromQL range queries against the ClickHouse-internal Prometheus endpoint (typically 15s scrape, native CH labels: type, shard, replica, instance, ready).
+
+Use this for ClickHouseMetrics_*, ClickHouseProfileEvents_*, ClickHouseAsyncMetrics_*. For K8s/fleet metrics (kube_*, container_*, node_*, kminion_*) use prometheus_query instead.
+
+start/end: RFC3339 UTC or relative ("-30m", "-1h"). end defaults to now(). Future timestamps are rejected.
+step: Go duration ("15s", "30s", "1m"). 15s exploits the upstream's native resolution.`
+		registerPrometheusTool(srv, "prometheus_query_clickhouse", "Query ClickHouse-internal Prometheus", chDesc, chPromEndpoint)
+	}
+
+	return runHTTPMCPServer(srv)
+}
+
+func registerPrometheusTool(srv *mcp.Server, name, title, description, endpoint string) {
 	mcp.AddTool[prometheusArgs, map[string]any](
 		srv,
 		&mcp.Tool{
-			Name:        "prometheus_query",
-			Title:       "Query Prometheus metrics",
-			Description: "Execute PromQL queries against Prometheus metrics",
+			Name:        name,
+			Title:       title,
+			Description: description,
 			Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 		},
 		func(ctx context.Context, ss *mcp.ServerSession, req *mcp.CallToolParamsFor[prometheusArgs]) (*mcp.CallToolResultFor[map[string]any], error) {
@@ -98,9 +120,6 @@ Investigation tips:
 			if pa.Query == "" {
 				return nil, fmt.Errorf("query is required")
 			}
-
-			var result interface{}
-			var err error
 
 			start, end, err := validateAndParseTimeRange(pa.Start, pa.End)
 			if err != nil {
@@ -112,14 +131,13 @@ Investigation tips:
 				return nil, fmt.Errorf("invalid step duration: %v", err)
 			}
 
-			result, err = queryPrometheus(pa.Query, start, end, step)
+			result, err := queryPrometheus(endpoint, pa.Query, start, end, step)
 			if err != nil {
 				return nil, err
 			}
 
 			data := map[string]any{"result": result}
 
-			// Create a simple summary showing the raw values
 			var summary string
 			if resultMap, ok := result.(map[string]interface{}); ok {
 				if lastValues, ok := resultMap["last_values"].([]map[string]interface{}); ok && len(lastValues) > 0 {
@@ -145,8 +163,6 @@ Investigation tips:
 			}, nil
 		},
 	)
-
-	return runHTTPMCPServer(srv)
 }
 
 // runHTTPMCPServer starts the MCP server over HTTP using the streamable HTTP transport.

--- a/sdk_mcp.go
+++ b/sdk_mcp.go
@@ -83,13 +83,35 @@ Investigation tips:
 		},
 	)
 
-	// Register Prometheus tool
+	defaultPromDesc := `Execute PromQL range queries against Prometheus metrics.
+
+start/end: RFC3339 UTC or relative ("-30m", "-1h"). end defaults to now(). Future timestamps are rejected. Prefer relative ("-30m") when the current time isn't known.
+step: Go duration ("30s", "1m"). Pick one that yields <~50 points over the window.`
+	if hasClickhousePromEndpoint() {
+		defaultPromDesc += "\n\nFor ClickHouse-internal metrics (ClickHouseMetrics_*, ClickHouseProfileEvents_*, ClickHouseAsyncMetrics_*) prefer prometheus_query_clickhouse — it hits a dedicated endpoint with higher scrape resolution."
+	}
+	registerPrometheusTool(srv, "prometheus_query", "Query Prometheus metrics", defaultPromDesc, defaultPromEndpoint)
+
+	if hasClickhousePromEndpoint() {
+		chDesc := `Execute PromQL range queries against the ClickHouse-internal Prometheus endpoint (typically 15s scrape, native CH labels: type, shard, replica, instance, ready).
+
+Use this for ClickHouseMetrics_*, ClickHouseProfileEvents_*, ClickHouseAsyncMetrics_*. For K8s/fleet metrics (kube_*, container_*, node_*, etc.) use prometheus_query instead.
+
+start/end: RFC3339 UTC or relative ("-30m", "-1h"). end defaults to now(). Future timestamps are rejected.
+step: Go duration ("15s", "30s", "1m"). 15s exploits the upstream's native resolution.`
+		registerPrometheusTool(srv, "prometheus_query_clickhouse", "Query ClickHouse-internal Prometheus", chDesc, chPromEndpoint)
+	}
+
+	return runHTTPMCPServer(srv)
+}
+
+func registerPrometheusTool(srv *mcp.Server, name, title, description, endpoint string) {
 	mcp.AddTool[prometheusArgs, map[string]any](
 		srv,
 		&mcp.Tool{
-			Name:        "prometheus_query",
-			Title:       "Query Prometheus metrics",
-			Description: "Execute PromQL queries against Prometheus metrics",
+			Name:        name,
+			Title:       title,
+			Description: description,
 			Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 		},
 		func(ctx context.Context, ss *mcp.ServerSession, req *mcp.CallToolParamsFor[prometheusArgs]) (*mcp.CallToolResultFor[map[string]any], error) {
@@ -98,9 +120,6 @@ Investigation tips:
 			if pa.Query == "" {
 				return nil, fmt.Errorf("query is required")
 			}
-
-			var result interface{}
-			var err error
 
 			start, end, err := validateAndParseTimeRange(pa.Start, pa.End)
 			if err != nil {
@@ -112,14 +131,13 @@ Investigation tips:
 				return nil, fmt.Errorf("invalid step duration: %v", err)
 			}
 
-			result, err = queryPrometheus(pa.Query, start, end, step)
+			result, err := queryPrometheus(endpoint, pa.Query, start, end, step)
 			if err != nil {
 				return nil, err
 			}
 
 			data := map[string]any{"result": result}
 
-			// Create a simple summary showing the raw values
 			var summary string
 			if resultMap, ok := result.(map[string]interface{}); ok {
 				if lastValues, ok := resultMap["last_values"].([]map[string]interface{}); ok && len(lastValues) > 0 {
@@ -145,8 +163,6 @@ Investigation tips:
 			}, nil
 		},
 	)
-
-	return runHTTPMCPServer(srv)
 }
 
 // runHTTPMCPServer starts the MCP server over HTTP using the streamable HTTP transport.


### PR DESCRIPTION
…l prom endpoints

## Summary

Three independent MCP fixes:

1. **Reject future Prometheus timestamps** with an explicit error showing current UTC, instead of silently returning empty (which was indistinguishable from "metric doesn't exist" and sent investigations down the wrong path: datasource config, role permissions, etc.).
2. **Stringify JSON integers > 2^53** in ClickHouse query output. `normalized_query_hash` is `UInt64` and routinely exceeds 2^53; the JSON encoder rounds to the nearest IEEE-754 double, so feeding the result back into a `WHERE normalized_query_hash = ...` filter matches the wrong row (or nothing). Now serialized as a string for any int/uint outside the safe range, preserving exact round-trip.
3. **Optional second Prometheus endpoint** via a new `prometheus_clickhouse:` config block. When set, the server registers a second tool, `prometheus_query_clickhouse`, bound to the new endpoint. Useful for routing ClickHouse-internals to a higher-resolution upstream