### PR TITLE
feat: split diagnose/query tool descriptions + log Bedrock token usage

### DIFF
--- a/bedrock.go
+++ b/bedrock.go
@@ -74,6 +74,7 @@ func runBedrockAgent(
 	}}
 
 	var finalText string
+	var inTok, outTok int32 // accumulated Bedrock token usage across iterations
 	for i := int32(0); i < maxIterations; i++ {
 		out, err := client.Converse(ctx, &bedrockruntime.ConverseInput{
 			ModelId:  aws.String(modelID),
@@ -87,6 +88,10 @@ func runBedrockAgent(
 		})
 		if err != nil {
 			return "", fmt.Errorf("bedrock converse: %w", err)
+		}
+		if out.Usage != nil {
+			inTok += aws.ToInt32(out.Usage.InputTokens)
+			outTok += aws.ToInt32(out.Usage.OutputTokens)
 		}
 
 		msgOut, ok := out.Output.(*types.ConverseOutputMemberMessage)
@@ -131,6 +136,9 @@ func runBedrockAgent(
 
 		if out.StopReason != types.StopReasonToolUse || len(toolResults) == 0 {
 			// Model is done (or asked for no tools) — finalText holds the answer.
+			logrus.WithFields(logrus.Fields{
+				"iterations": i + 1, "input_tokens": inTok, "output_tokens": outTok,
+			}).Info("diagnose: complete")
 			return finalText, nil
 		}
 
@@ -141,6 +149,9 @@ func runBedrockAgent(
 		})
 	}
 
+	logrus.WithFields(logrus.Fields{
+		"iterations": maxIterations, "input_tokens": inTok, "output_tokens": outTok,
+	}).Info("diagnose: hit iteration budget")
 	if finalText != "" {
 		return finalText + "\n\n(note: investigation hit the iteration budget; answer may be partial)", nil
 	}

--- a/config.go
+++ b/config.go
@@ -48,10 +48,13 @@ func loadConfig(explicitPath string) error {
 	viper.SetDefault("http.addr", ":8080")
 	viper.SetDefault("http.auth_token", "")
 
-	// Optional deployment-specific guidance appended to the clickhouse_query tool
-	// description. Lets operators ship private context (instance sizes, common
-	// query patterns, owning teams) without forking the upstream description.
+	// Deployment-specific guidance. extra_tool_description is shared facts
+	// appended to BOTH clickhouse_query and the diagnose agent (topology,
+	// clusters, attribution columns, query patterns). query_extra_description is
+	// appended ONLY to clickhouse_query — for restricted-route caveats (column
+	// REVOKEs, etc.) that don't apply to the elevated diagnose connection.
 	viper.SetDefault("mcp.extra_tool_description", "")
+	viper.SetDefault("mcp.query_extra_description", "")
 
 	// Bedrock-backed in-MCP diagnose tool. Empty region/model_id disables the
 	// diagnose tool. model_id is a Bedrock model or inference-profile

--- a/configs/config.yml.sample
+++ b/configs/config.yml.sample
@@ -39,12 +39,15 @@ http:
   addr: ":8080"           # Listen address
   auth_token: ""          # Bearer token clients must present (leave empty to disable auth)
 
-# Optional: deployment-specific guidance appended to the clickhouse_query tool
-# description visible to MCP clients. Useful for adding instance-size context,
-# common query patterns, or owning-team callouts without forking the binary.
-# Env var equivalent: HOUSEKEEPER_MCP_EXTRA_TOOL_DESCRIPTION
+# Optional: deployment-specific guidance for MCP clients.
+# - extra_tool_description: shared facts (topology, clusters, attribution columns,
+#   query patterns), appended to BOTH clickhouse_query and the diagnose agent.
+# - query_extra_description: appended ONLY to clickhouse_query, for restricted-route
+#   caveats (column REVOKEs etc.) that don't apply to the elevated diagnose connection.
+# Env vars: HOUSEKEEPER_MCP_EXTRA_TOOL_DESCRIPTION, HOUSEKEEPER_MCP_QUERY_EXTRA_DESCRIPTION
 mcp:
   extra_tool_description: ""
+  query_extra_description: ""
 
 # Optional: in-account Bedrock-backed diagnose tool. When both region and
 # model_id are set, the MCP exposes a server-side agent that investigates the

--- a/sdk_mcp.go
+++ b/sdk_mcp.go
@@ -46,12 +46,14 @@ Investigation tips:
 - Many apps tag queries with log_comment metadata, often surfaced as lc_* columns (e.g. lc_product, lc_workflow). These attribute a normalized_query_hash to the owning service/job/team in one query.
 - normalized_query_hash collapses identical queries with different literals. count() + sum(query_duration_ms) GROUP BY normalized_query_hash is the canonical "what's hammering us" query.`, dbList)
 
-	// Operators can append deployment-specific guidance (instance sizes, owning
-	// teams, common patterns) via mcp.extra_tool_description in config or the
-	// HOUSEKEEPER_MCP_EXTRA_TOOL_DESCRIPTION env var. This lets PostHog (or any
-	// org) ship private context without forking the public description.
+	// Shared deployment guidance (also given to the diagnose agent).
 	if extra := strings.TrimSpace(viper.GetString("mcp.extra_tool_description")); extra != "" {
 		toolDesc = toolDesc + "\n\nDeployment-specific guidance:\n" + extra
+	}
+	// clickhouse_query-only guidance (restricted-route caveats); not seen by the
+	// elevated diagnose agent.
+	if qextra := strings.TrimSpace(viper.GetString("mcp.query_extra_description")); qextra != "" {
+		toolDesc = toolDesc + "\n\n" + qextra
 	}
 
 	// Register ClickHouse tool with inferred input schema (from queryArgs)


### PR DESCRIPTION
- mcp.query_extra_description: restricted-route caveats for clickhouse_query
  only; shared extra_tool_description still feeds both tools
- log per-diagnose iterations + input/output tokens for cost visibility