### PR TITLE
feat: wall-clock budget for diagnose agent

### DIFF
--- a/bedrock.go
+++ b/bedrock.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -44,15 +45,16 @@ type bedrockTool struct {
 type toolHandler func(name string, input map[string]any) (string, error)
 
 // runBedrockAgent drives a Converse tool-use loop until the model produces a
-// final text answer (or the iteration budget is exhausted). It returns that
-// final text; tool results are consumed within the loop and not returned.
+// final answer or a limit is hit (iteration count or wall-clock budget). When
+// the time budget is exceeded it makes one final tool-free turn so the model
+// summarizes what it found rather than timing out the caller. Returns that text.
 func runBedrockAgent(
 	ctx context.Context,
 	client *bedrockruntime.Client,
 	modelID, system, userMsg string,
 	tools []bedrockTool,
 	handle toolHandler,
-	maxTokens, maxIterations int32,
+	maxTokens, maxIterations, maxSeconds int32,
 	temperature float32,
 ) (string, error) {
 	toolCfg := &types.ToolConfiguration{Tools: make([]types.Tool, 0, len(tools))}
@@ -75,17 +77,29 @@ func runBedrockAgent(
 
 	var finalText string
 	var inTok, outTok int32 // accumulated Bedrock token usage across iterations
+	var deadline time.Time
+	if maxSeconds > 0 {
+		deadline = time.Now().Add(time.Duration(maxSeconds) * time.Second)
+	}
+	timedOut := false
 	for i := int32(0); i < maxIterations; i++ {
-		out, err := client.Converse(ctx, &bedrockruntime.ConverseInput{
+		convInput := &bedrockruntime.ConverseInput{
 			ModelId:  aws.String(modelID),
 			System:   []types.SystemContentBlock{&types.SystemContentBlockMemberText{Value: system}},
 			Messages: messages,
-			ToolConfig: toolCfg,
 			InferenceConfig: &types.InferenceConfiguration{
 				MaxTokens:   aws.Int32(maxTokens),
 				Temperature: aws.Float32(temperature),
 			},
-		})
+		}
+		// Within the time budget the model may call tools; once exceeded, withhold
+		// them so it must summarize on this turn instead of investigating further.
+		if maxSeconds == 0 || time.Now().Before(deadline) {
+			convInput.ToolConfig = toolCfg
+		} else {
+			timedOut = true
+		}
+		out, err := client.Converse(ctx, convInput)
 		if err != nil {
 			return "", fmt.Errorf("bedrock converse: %w", err)
 		}
@@ -135,10 +149,13 @@ func runBedrockAgent(
 		}
 
 		if out.StopReason != types.StopReasonToolUse || len(toolResults) == 0 {
-			// Model is done (or asked for no tools) — finalText holds the answer.
+			// Model is done (or we withheld tools after the time budget).
 			logrus.WithFields(logrus.Fields{
-				"iterations": i + 1, "input_tokens": inTok, "output_tokens": outTok,
+				"iterations": i + 1, "input_tokens": inTok, "output_tokens": outTok, "timed_out": timedOut,
 			}).Info("diagnose: complete")
+			if timedOut {
+				return finalText + "\n\n(note: time budget reached; summary reflects findings so far)", nil
+			}
 			return finalText, nil
 		}
 

--- a/config.go
+++ b/config.go
@@ -64,6 +64,9 @@ func loadConfig(explicitPath string) error {
 	viper.SetDefault("bedrock.model_id", "")
 	viper.SetDefault("bedrock.max_tokens", 2048)
 	viper.SetDefault("bedrock.max_iterations", 8)
+	// Wall-clock budget for a diagnosis; once exceeded the agent stops calling
+	// tools and returns a summary so the MCP client doesn't time out. 0 disables.
+	viper.SetDefault("bedrock.max_seconds", 25)
 	viper.SetDefault("bedrock.temperature", 0.2)
 
 	// Optional separate ClickHouse connection used only by the server-side

--- a/configs/config.yml.sample
+++ b/configs/config.yml.sample
@@ -59,6 +59,7 @@ bedrock:
   model_id: ""           # Bedrock model or inference-profile id (set per deployment)
   max_tokens: 2048
   max_iterations: 8      # max run_sql round-trips per diagnosis
+  max_seconds: 25        # wall-clock budget; on exceed, summarize instead of timing out (0 = off)
   temperature: 0.2
 
 # Optional separate ClickHouse connection used only by the diagnose agent.

--- a/diagnose_mcp.go
+++ b/diagnose_mcp.go
@@ -239,6 +239,7 @@ func registerDiagnoseTool(srv *mcp.Server) {
 				[]bedrockTool{runSQL}, handle,
 				int32(viper.GetInt("bedrock.max_tokens")),
 				int32(viper.GetInt("bedrock.max_iterations")),
+				int32(viper.GetInt("bedrock.max_seconds")),
 				float32(viper.GetFloat64("bedrock.temperature")),
 			)
 			if err != nil {


### PR DESCRIPTION
Once bedrock.max_seconds is exceeded the agent stops calling tools and
returns a best-effort summary, so a long investigation responds to the
MCP client instead of timing out. Default 25s; 0 disables.