### PR TITLE
fix(mcp): accept multiline SELECT/WITH and close allowlist bypass in …

### DIFF
--- a/clickhouse_mcp.go
+++ b/clickhouse_mcp.go
@@ -241,8 +241,12 @@ func validateFreeformSQL(sql string) error {
 	if strings.Contains(s, ";") {
 		return fmt.Errorf("multiple statements are not allowed")
 	}
-	// Strip simple quoted strings to avoid false positives when scanning tokens
-	sanitized := stripQuotedLiterals(s)
+	// Strip simple quoted strings to avoid false positives when scanning tokens,
+	// then fold newlines/tabs to spaces so the space-padded keyword scans below
+	// treat multiline queries the same as single-line ones. Without this, a query
+	// starting "SELECT\n..." is rejected as non-SELECT, and a table reference
+	// after "\nFROM" escapes allowlist validation entirely.
+	sanitized := normalizeWhitespace(stripQuotedLiterals(s))
 	lower := strings.ToLower(strings.TrimSpace(sanitized))
 	if !strings.HasPrefix(lower, "select ") && !strings.HasPrefix(lower, "with ") {
 		return fmt.Errorf("only SELECT/WITH queries are allowed")
@@ -473,12 +477,34 @@ func isIdentChar(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
 }
 
+// normalizeWhitespace folds tabs, newlines, and carriage returns to single
+// spaces. Only used on the sanitized scan copy — the original SQL is what gets
+// sent to ClickHouse.
+func normalizeWhitespace(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\t', '\n', '\r':
+			return ' '
+		}
+		return r
+	}, s)
+}
+
 func stripQuotedLiterals(s string) string {
 	var b strings.Builder
 	inSingle, inDouble := false, false
 	for i := 0; i < len(s); i++ {
 		ch := s[i]
 		if inSingle {
+			// ClickHouse escapes quotes inside string literals with a backslash
+			// ('it\'s'); consume the escaped character so it can't terminate the
+			// literal and desync the scan.
+			if ch == '\\' && i+1 < len(s) {
+				i++
+				b.WriteByte(' ')
+				b.WriteByte(' ')
+				continue
+			}
 			if ch == '\'' {
 				inSingle = false
 			}
@@ -486,6 +512,12 @@ func stripQuotedLiterals(s string) string {
 			continue
 		}
 		if inDouble {
+			if ch == '\\' && i+1 < len(s) {
+				i++
+				b.WriteByte(' ')
+				b.WriteByte(' ')
+				continue
+			}
 			if ch == '"' {
 				inDouble = false
 			}

--- a/clickhouse_mcp_test.go
+++ b/clickhouse_mcp_test.go
@@ -279,6 +279,32 @@ func TestValidateFreeformSQL(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "multiline SELECT with newline after keyword",
+			sql:     "SELECT\n    count()\nFROM system.query_log\nWHERE query_duration_ms > 1000",
+			wantErr: false,
+		},
+		{
+			name:    "multiline WITH with newline after keyword",
+			sql:     "WITH\n    slow AS (SELECT query_id FROM system.query_log)\nSELECT count() FROM slow",
+			wantErr: false,
+		},
+		{
+			name:    "multiline FROM does not bypass table allowlist",
+			sql:     "SELECT 1\nFROM users.data",
+			wantErr: true,
+			errMsg:  "only tables from allowed databases",
+		},
+		{
+			name:    "dollar-sign property literals are allowed",
+			sql:     "SELECT count() FROM system.query_log WHERE query LIKE '%$geoip_city_name%'",
+			wantErr: false,
+		},
+		{
+			name:    "backslash-escaped quote does not desync literal stripping",
+			sql:     `SELECT count() FROM system.query_log WHERE query = 'it\'s from users.data'`,
+			wantErr: false,
+		},
+		{
 			name:    "CTE referenced by name in FROM",
 			sql:     "WITH slow AS (SELECT query_duration_ms FROM system.query_log WHERE query_duration_ms > 1000) SELECT count() FROM slow",
 			wantErr: false,


### PR DESCRIPTION
…SQL validator

Summary
The free-form SQL validator rejected any multiline query (SELECT\n...) with a misleading "only SELECT/WITH queries are allowed" error, and its space-padded keyword scan let \nFROM db.table references skip table-allowlist validation.
Changes

Normalize tabs/newlines to spaces in the sanitized scan copy before prefix, forbidden-keyword, and table-ref checks; original SQL sent to ClickHouse is unchanged
Handle backslash-escaped quotes in stripQuotedLiterals so literals containing \' can't desync token scanning
Add regression tests: multiline SELECT/WITH accepted, multiline unauthorized FROM rejected, $-literals accepted, escaped-quote literals stripped correctly