### PR TITLE
ci: publish PR images to a -prs repo and drop master publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ permissions:
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master]
+    branches: [main]
 
 env:
   GO_VERSION: "1.23"
@@ -57,10 +57,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
+      # PR builds publish to the housekeeper-prs repo via the any-branch role; main
+      # builds publish to the prod housekeeper repo via the main-only role.
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
-          role-to-assume: ${{ vars.AWS_ECR_PUBLISH_IAM_ROLE }}
+          role-to-assume: ${{ github.event_name == 'pull_request' && vars.AWS_ECR_PRS_PUBLISH_IAM_ROLE || vars.AWS_ECR_PUBLISH_IAM_ROLE }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
@@ -71,7 +73,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
-          images: ${{ steps.aws-ecr.outputs.registry }}/housekeeper
+          images: ${{ steps.aws-ecr.outputs.registry }}/${{ github.event_name == 'pull_request' && 'housekeeper-prs' || 'housekeeper' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0


### PR DESCRIPTION
Gives `housekeeper` a least-privilege ECR publish setup: PR builds push to the mutable `housekeeper-prs` repo (via an any-branch role), and `main` builds push to the prod `housekeeper` repo (via a main-only role). Also drops `master` from the triggers — the default branch is `main` and master publishing was unintentional.

Part of splitting the shared `github-posthog-ecr-publish-role` (trusts ~18 repos on `resource:*`) into per-repo roles so the prod repo can only be written from `main`.

**Depends on** the infra PR that creates the `housekeeper-prs` repo and the two housekeeper roles. Set repo variables `AWS_ECR_PUBLISH_IAM_ROLE` (main role ARN) and `AWS_ECR_PRS_PUBLISH_IAM_ROLE` (prs role ARN) before merging, or the workflow will fail to assume.