### PR TITLE
docs: refresh CLAUDE/AGENTS/MCP/README to match MCP-first architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - MCP server: `sdk_mcp.go` (server, transport, middleware), `clickhouse_mcp.go` (validation + query execution), `prometheus_mcp.go` (PromQL tools), `diagnose_mcp.go` + `bedrock.go` (optional in-account diagnose agent).
 - Legacy analysis mode: `agent.go` (Gemini), `clickhouse.go` (error queries), `slack.go` (webhook).
 - Configs in `configs/` (`config.yml.sample` template; user `config.yml` gitignored).
-- Local infra: `docker-compose.yml` (ClickHouse). PostHog's Kubernetes deployment config lives in private internal repos.
+- Local infra: `docker-compose.yml` (ClickHouse).
 
 ## Build, Test, and Development Commands
 - Build: `go build -o housekeeper`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,35 +1,36 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- Root Go module; entrypoint: `main.go`.
-- Core packages: `agent.go` (Gemini analysis + tools), `clickhouse.go` (CH queries), `config.go` (Viper config), `slack.go` (Slack webhook).
-- Configs in `configs/` (`config.yml.sample`, user `config.yml`).
-- Local infra: `docker-compose.yml`, `docker/` (ClickHouse volumes).
+- Root Go module; entrypoint: `main.go` (MCP server by default; `--analyze` runs the legacy Gemini mode).
+- MCP server: `sdk_mcp.go` (server, transport, middleware), `clickhouse_mcp.go` (validation + query execution), `prometheus_mcp.go` (PromQL tools), `diagnose_mcp.go` + `bedrock.go` (optional in-account diagnose agent).
+- Legacy analysis mode: `agent.go` (Gemini), `clickhouse.go` (error queries), `slack.go` (webhook).
+- Configs in `configs/` (`config.yml.sample` template; user `config.yml` gitignored).
+- Local infra: `docker-compose.yml` (ClickHouse). PostHog's Kubernetes deployment config lives in private internal repos.
 
 ## Build, Test, and Development Commands
-- Build: `go build -o housekeeper` — compiles the CLI binary.
-- Run (errors mode): `./housekeeper` — analyzes recent CH errors and prints a Slack-formatted summary.
-- Run (performance mode): `./housekeeper -performance` — analyzes recent slow queries.
-- Dev run: `go run .` (supports `-performance`).
-- Local ClickHouse: `docker-compose up -d` / teardown: `docker-compose down`.
+- Build: `go build -o housekeeper`.
+- Run MCP server (default): `go run .` — serves streamable HTTP MCP on `http.addr` (default `:8080`), health at `/health`.
+- Run with config: `go run . --config configs/config.yml`.
+- Legacy analysis: `go run . --analyze` (errors) / `--analyze --performance` (slow queries); requires `gemini_key`.
+- Local ClickHouse: `docker-compose up -d` / `docker-compose down`.
 
 ## Coding Style & Naming Conventions
 - Go 1.23+ module; format with `gofmt -s -w .` and vet with `go vet ./...`.
 - Naming: exported identifiers use `CamelCase`; unexported use `lowerCamel`.
-- Files group by responsibility (agent, data access, config, integrations). Keep functions small and composable.
-- Configuration keys mirror `configs/config.yml` (e.g., `clickhouse.host`, `gemini_key`, `slack.webhook_url`).
+- Files group by responsibility (MCP tools, data access, config, integrations). Keep functions small and composable.
+- Configuration keys mirror `configs/config.yml.sample` (e.g., `clickhouse.host`, `bedrock.model_id`, `mcp.extra_tool_description`). Env vars use the `HOUSEKEEPER_` prefix with dots as underscores.
 
 ## Testing Guidelines
-- Current repo has no `_test.go` files. Add table-driven tests alongside source (e.g., `agent_test.go`).
-- Run tests: `go test ./...` (add `-v -race` when relevant). Aim for coverage on parsing, formatting, and query builders.
-- Prefer dependency seams for external calls (ClickHouse, Slack, Gemini) to allow mocking.
+- Table-driven tests live alongside source: `clickhouse_mcp_test.go` (SQL validator — extend this for ANY validator change), `clickhouse_test.go`, `prometheus_mcp_test.go`.
+- Run tests: `go test ./...` (add `-v -race` when relevant).
+- The free-form SQL validator is security-relevant defense-in-depth; add a test for every accepted/rejected shape you change. Server-side grants/REVOKEs remain the real boundary.
 
 ## Commit & Pull Request Guidelines
 - Commits: imperative, concise, present tense (e.g., "add performance agent hints"). Group logical changes; avoid noise.
 - PRs include: clear description, rationale, test plan/steps, config changes, and any screenshots/log snippets of output.
-- Link related issues; call out backward-incompatible changes and ops impacts.
+- Link related issues; call out backward-incompatible changes and ops impacts (tool descriptions in the charts repo are operator-facing surface).
 
 ## Security & Configuration Tips
 - Do not commit secrets. Copy `configs/config.yml.sample` to `configs/config.yml` and keep it local (gitignored).
-- Required fields: `gemini_key`, `slack.webhook_url`, and `clickhouse.*` (including `cluster`).
-- Validate connectivity before large queries; prefer least-privileged DB credentials.
+- MCP mode needs `clickhouse.*` (+ `prometheus.*`); the diagnose tool additionally needs `bedrock.region`, `bedrock.model_id`, and ideally a dedicated `analyst_clickhouse.*` user. `gemini_key`/`slack.webhook_url` are only for the legacy `--analyze` mode.
+- Prefer least-privileged DB credentials; raw query text and customer tables belong only on the analyst connection.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,89 +4,60 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Housekeeper is an MCP-first application** that runs as a Model Context Protocol server by default, providing AI assistants with direct access to ClickHouse system tables and Prometheus metrics.
+**Housekeeper is an MCP-first application**: by default it runs an HTTP MCP server (streamable HTTP transport) that gives AI assistants read-only access to ClickHouse and Prometheus/Victoria Metrics, plus an optional in-account LLM diagnosis tool.
 
-### Primary Mode: MCP Server (Default)
-When run without flags, Housekeeper starts an MCP server that exposes:
-- **clickhouse_query**: Read-only access to ClickHouse system tables
-- **prometheus_query**: Execute PromQL queries against Prometheus/Victoria Metrics
+### MCP tools exposed
 
-### Analysis Mode (Optional)
-With the `--analyze` flag, it monitors and analyzes ClickHouse database errors using Google's Gemini AI, generating summaries suitable for Slack notifications.
+- **clickhouse_query** — read-only queries (structured fields or free-form single SELECT/WITH), restricted to `clickhouse.allowed_databases`. Free-form SQL goes through the validator in `clickhouse_mcp.go` (allowlist of table refs, forbidden keywords, quote/whitespace normalization).
+- **prometheus_query** — PromQL range queries against the main Prometheus/VM endpoint.
+- **prometheus_query_clickhouse** — same interface against a dedicated ClickHouse-internals metrics endpoint; only registered when `prometheus_clickhouse.host` is set.
+- **clickhouse_diagnose** — only registered when `bedrock.region` + `bedrock.model_id` are set. Runs a server-side Bedrock Converse tool-use loop (`bedrock.go`) with a single `run_sql` tool against the elevated `analyst_clickhouse.*` connection, bounded by `bedrock.max_iterations` and `bedrock.max_seconds`, and returns only a text summary. The system prompt lives in `diagnose_mcp.go`; deployment-specific context is appended from `mcp.extra_tool_description`.
+
+### Analysis Mode (legacy, optional)
+
+With `--analyze`, runs a one-shot Gemini-based error analysis (`agent.go`, `slack.go`, `clickhouse.go`) and posts to Slack. Not used by the Kubernetes deployments.
 
 ## Development Commands
 
-### Running the Application
 ```bash
-# Run as MCP server (default)
-go run .
-
-# Run in analysis mode (Gemini AI error analysis)
-go run . --analyze
-
-# Run performance analysis
-go run . --analyze --performance
-
-# Build the application
-go build -o housekeeper
-
-# Run with custom config
+go run .                          # MCP server (default)
 go run . --config configs/config.yml
-```
-
-### Development Environment
-```bash
-# Start local ClickHouse instance
-docker-compose up -d
-
-# Stop ClickHouse
-docker-compose down
-
-# View ClickHouse logs
-docker-compose logs clickhouse
-```
-
-### Dependency Management
-```bash
-# Download dependencies
-go mod download
-
-# Update dependencies
-go mod tidy
-
-# Verify dependencies
-go mod verify
+go build -o housekeeper
+go test ./...                     # tests exist: validator, query building, prometheus parsing
+gofmt -s -w . && go vet ./...
+docker-compose up -d              # local ClickHouse
 ```
 
 ## Architecture
 
-### Core Components
-1. **main.go** - Application entry point, defaults to MCP server mode
-2. **mcp_server.go** - MCP server implementation with clickhouse_query and prometheus_query tools
-3. **config.go** - Manages configuration via command-line flags or YAML config
-4. **clickhouse.go** - Handles ClickHouse connections and queries across cluster replicas
-5. **prometheus.go** - Prometheus/Victoria Metrics client for metrics queries
-6. **gemini.go** - Integrates with Google Gemini AI for error analysis (analysis mode only)
+### Core files
 
-### Configuration Structure
-The application expects a `configs/config.yml` file (copy from `configs/config.yml.sample`):
-- `gemini_api_key`: Google Gemini API key
-- `clickhouse`: Connection parameters including host, port, user, password, database, and cluster name
+1. **main.go** — entry point, pflag definitions, mode selection
+2. **sdk_mcp.go** — MCP server (go-sdk), tool registration, tool descriptions, HTTP transport + auth/CORS/logging middleware, row summarization
+3. **clickhouse_mcp.go** — query args validation, free-form SQL validator, query building/execution, value normalization
+4. **prometheus_mcp.go** — Prometheus/VM clients (default + optional clickhouse endpoint), time-range validation
+5. **diagnose_mcp.go** — clickhouse_diagnose tool, analyst connection, diagnose system prompt
+6. **bedrock.go** — Bedrock client (IRSA/default AWS credential chain), Converse tool-use loop with iteration + wall-clock budgets
+7. **config.go** — Viper config: defaults, `HOUSEKEEPER_*` env vars (dots → underscores), config file search paths
+8. **clickhouse.go / agent.go / slack.go** — legacy `--analyze` mode (Gemini + Slack)
 
-### Key Design Patterns
-- **MCP-first architecture**: Runs as MCP server by default for AI assistant integration
-- **Cluster-aware querying**: Queries all replicas using `clusterAllReplicas()` function
-- **Read-only enforcement**: MCP mode restricts queries to system tables only
-- **Flexible configuration**: Supports both command-line flags and YAML config
-- **Time-based filtering**: Analysis mode focuses on errors from the last hour
-- **AI prompt engineering**: Uses specific prompts for Slack-friendly summaries
+### Configuration
+
+Priority: CLI flags > env vars > config file > defaults. Notable keys beyond connection params:
+
+- `mcp.extra_tool_description` — deployment-specific guidance appended to BOTH the clickhouse_query description and the diagnose agent's system prompt
+- `mcp.query_extra_description` — appended ONLY to clickhouse_query (restricted-role caveats the elevated diagnose agent must not see)
+- `bedrock.*` — enables clickhouse_diagnose (region + model_id), budgets, temperature
+- `analyst_clickhouse.*` — elevated connection for the diagnose agent; falls back to `clickhouse.*` when unset
+
+### Deployment
+
+PostHog's Kubernetes deployment (Helm chart, ArgoCD, per-environment tool descriptions, Bedrock IRSA) lives in private internal repos. The server itself is deployment-agnostic: everything operator-facing is set via flags, config file, or `HOUSEKEEPER_*` env vars.
 
 ## Important Notes
 
-1. **MCP is default mode** - Application runs as MCP server unless `--analyze` flag is used
-2. **No tests exist** - When adding features, consider creating a test suite
-3. **Configuration security** - Ensure `configs/config.yml` remains in .gitignore
-4. **ClickHouse connection** - Uses native protocol on port 9000 by default
-5. **MCP restrictions** - Server enforces read-only access to `system.*` tables only
-6. **Error handling** - The application uses `log.Fatal()` for errors, which exits the program
-7. **Local development** - Docker Compose provides a local ClickHouse instance with default credentials
+1. **MCP is the default mode** — `--analyze` is legacy and unused in k8s.
+2. **Security boundary is server-side** — the SQL validator is defense-in-depth; the ClickHouse role/profile (grants, column REVOKEs) is the real boundary. Keep both in mind when changing the validator.
+3. **Tool descriptions are product surface** — most operator-facing behavior is prompt text supplied via the `mcp.extra_tool_description` / `mcp.query_extra_description` config keys, not Go code. Check deployment config first for instruction changes.
+4. **Config security** — `configs/config*.yml` are gitignored; only `*.sample`/`*.example` are tracked.
+5. **Tests** — table-driven tests in `clickhouse_mcp_test.go`, `clickhouse_test.go`, `prometheus_mcp_test.go`. Extend them when touching the validator; bypasses have happened (multiline whitespace).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Analysis Mode (legacy, optional)
 
-With `--analyze`, runs a one-shot Gemini-based error analysis (`agent.go`, `slack.go`, `clickhouse.go`) and posts to Slack. Not used by the Kubernetes deployments.
+With `--analyze`, runs a one-shot Gemini-based error analysis (`agent.go`, `slack.go`, `clickhouse.go`) and posts to Slack. Legacy; not used in MCP server deployments.
 
 ## Development Commands
 
@@ -37,7 +37,7 @@ docker-compose up -d              # local ClickHouse
 3. **clickhouse_mcp.go** — query args validation, free-form SQL validator, query building/execution, value normalization
 4. **prometheus_mcp.go** — Prometheus/VM clients (default + optional clickhouse endpoint), time-range validation
 5. **diagnose_mcp.go** — clickhouse_diagnose tool, analyst connection, diagnose system prompt
-6. **bedrock.go** — Bedrock client (IRSA/default AWS credential chain), Converse tool-use loop with iteration + wall-clock budgets
+6. **bedrock.go** — Bedrock client (default AWS credential chain), Converse tool-use loop with iteration + wall-clock budgets
 7. **config.go** — Viper config: defaults, `HOUSEKEEPER_*` env vars (dots → underscores), config file search paths
 8. **clickhouse.go / agent.go / slack.go** — legacy `--analyze` mode (Gemini + Slack)
 
@@ -52,7 +52,7 @@ Priority: CLI flags > env vars > config file > defaults. Notable keys beyond con
 
 ### Deployment
 
-PostHog's Kubernetes deployment (Helm chart, ArgoCD, per-environment tool descriptions, Bedrock IRSA) lives in private internal repos. The server itself is deployment-agnostic: everything operator-facing is set via flags, config file, or `HOUSEKEEPER_*` env vars.
+The server is deployment-agnostic: everything operator-facing is set via flags, config file, or `HOUSEKEEPER_*` env vars.
 
 ## Important Notes
 

--- a/MCP.md
+++ b/MCP.md
@@ -131,7 +131,7 @@ The server uses the official go-sdk and serves MCP over HTTP using the streamabl
 ### Tool: clickhouse_diagnose (optional)
 
 - Name: `clickhouse_diagnose`
-- Description: Ask a natural-language question about ClickHouse health; a server-side Bedrock agent (Anthropic model via the pod's IRSA role) investigates with a guarded `run_sql` tool on the elevated `analyst_clickhouse.*` connection and returns only a text summary — raw query text never leaves the account.
+- Description: Ask a natural-language question about ClickHouse health; a server-side Bedrock agent (credentials from the default AWS chain) investigates with a guarded `run_sql` tool on the elevated `analyst_clickhouse.*` connection and returns only a text summary — raw query text never leaves the account.
 - Registration: only exposed when both `bedrock.region` and `bedrock.model_id` are set.
 - Arguments: `question` (required), `cluster` (optional focus hint).
 - Budgets: `bedrock.max_iterations` run_sql round-trips and `bedrock.max_seconds` wall-clock; on exceeding the time budget the agent stops investigating and summarizes findings so far. The MCP client's tool timeout must exceed `bedrock.max_seconds` (e.g. `MCP_TOOL_TIMEOUT` in Claude Code) or the client gives up while the server keeps working.

--- a/MCP.md
+++ b/MCP.md
@@ -4,6 +4,7 @@
 1. Read‑only queries against configurable ClickHouse databases
 2. Querying Prometheus metrics for monitoring and correlation
 3. (Optional) Querying a separate Prometheus endpoint for ClickHouse-internal metrics
+4. (Optional) An in-account, Bedrock-backed diagnosis agent (`clickhouse_diagnose`)
 
 > **Looking for investigation guidance?** See [INVESTIGATION_PLAYBOOK.md](./INVESTIGATION_PLAYBOOK.md) for a methodology and `system.*` query patterns for diagnosing ClickHouse + ZooKeeper issues using these tools.
 
@@ -106,10 +107,9 @@ The server uses the official go-sdk and serves MCP over HTTP using the streamabl
 - Allowed databases: Configured via `--ch-allowed-databases` flag or `clickhouse.allowed_databases` in config (defaults to ["system"])
 
 **IMPORTANT Usage Guidelines:**
-- **For system.* tables**: The tool automatically uses `clusterAllReplicas()` to get cluster-wide data
-- **For non-system databases**: Do NOT use `clusterAllReplicas()` in your SQL queries. Query these tables directly.
-- Example for system tables: Tool converts `system.query_log` → `clusterAllReplicas(cluster, system.query_log)`
-- Example for other tables: Query `models.predictions` directly without cluster functions
+- **Structured mode auto-wraps `system.*`**: the tool converts `system.query_log` → `clusterAllReplicas(cluster, system.query_log)` for cluster-wide data. Non-system tables are queried directly. Note: on deployments with column REVOKEs on query-log tables, this forced wrap fails (a distributed read demands the whole-table grant) — use free-form `sql` with a plain single-node read for those tables.
+- **Free-form mode wraps nothing** — choose per table: replicated tables (same data everywhere) → query directly to avoid duplicate rows; sharded tables and per-node `system.*` → wrap in `clusterAllReplicas('<cluster>', db.table)` to see everything. Check `system.tables.engine` if unsure.
+- Only `db.table` and `clusterAllReplicas('cluster', db.table)` references are accepted; `cluster()` and `remote()` are blocked.
 
 ### Tool: prometheus_query
 
@@ -127,6 +127,14 @@ The server uses the official go-sdk and serves MCP over HTTP using the streamabl
 - Description: Same PromQL interface as `prometheus_query`, but targets a separate endpoint dedicated to ClickHouse-internal metrics (`ClickHouseMetrics_*`, `ClickHouseProfileEvents_*`, `ClickHouseAsyncMetrics_*`).
 - Registration: only exposed when `prometheus_clickhouse.host` is set in config.
 - Arguments: identical to `prometheus_query`.
+
+### Tool: clickhouse_diagnose (optional)
+
+- Name: `clickhouse_diagnose`
+- Description: Ask a natural-language question about ClickHouse health; a server-side Bedrock agent (Anthropic model via the pod's IRSA role) investigates with a guarded `run_sql` tool on the elevated `analyst_clickhouse.*` connection and returns only a text summary — raw query text never leaves the account.
+- Registration: only exposed when both `bedrock.region` and `bedrock.model_id` are set.
+- Arguments: `question` (required), `cluster` (optional focus hint).
+- Budgets: `bedrock.max_iterations` run_sql round-trips and `bedrock.max_seconds` wall-clock; on exceeding the time budget the agent stops investigating and summarizes findings so far. The MCP client's tool timeout must exceed `bedrock.max_seconds` (e.g. `MCP_TOOL_TIMEOUT` in Claude Code) or the client gives up while the server keeps working.
 
 ## Example tools/call
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Housekeeper runs as an HTTP MCP server, providing AI assistants like Claude with
 - **ClickHouse Queries**: Read-only access to configurable databases (defaults to `system.*` tables)
 - **Prometheus/Victoria Metrics**: Execute PromQL queries for metrics correlation and analysis
 - **ClickHouse-internal metrics (optional)**: Configure a second Prometheus/Victoria Metrics endpoint to expose a dedicated `prometheus_query_clickhouse` tool
+- **In-account diagnosis (optional)**: A Bedrock-backed `clickhouse_diagnose` tool that investigates server-side on an elevated connection and returns only a summary
 - **Smart Cluster Querying**: Automatic use of `clusterAllReplicas()` for system tables only (non-system tables are queried directly)
 
 ---
@@ -80,6 +81,9 @@ Example requests:
 
 ### `prometheus_query_clickhouse` (optional)
 Same PromQL interface as `prometheus_query`, but targets a separate endpoint dedicated to ClickHouse-internal metrics (`ClickHouseMetrics_*`, `ClickHouseProfileEvents_*`, `ClickHouseAsyncMetrics_*`). Only registered when `prometheus_clickhouse.host` is set in config (see [Configuration](#️-configuration)). Use `prometheus_query` for general fleet/host metrics and `prometheus_query_clickhouse` for ClickHouse server internals.
+
+### `clickhouse_diagnose` (optional)
+Ask a natural-language question ("why is X slow", "what's driving load") and a server-side Bedrock agent investigates via a guarded `run_sql` tool on a separate, elevated ClickHouse connection, returning only an attributed summary. Registered when `bedrock.region` + `bedrock.model_id` are set; credentials come from the default AWS chain (in-cluster: IRSA). Bounded by `bedrock.max_iterations` / `bedrock.max_seconds` — make sure your MCP client's tool timeout exceeds the latter. See [MCP.md](./MCP.md) for details.
 
 ---
 
@@ -221,19 +225,23 @@ clickhouse:
 ```
 .
 ├── main.go                  # Entry point, flag definitions
-├── sdk_mcp.go               # HTTP MCP server, middlewares
+├── sdk_mcp.go               # HTTP MCP server, tool registration, middlewares
 ├── clickhouse_mcp.go        # ClickHouse query validation and execution
 ├── prometheus_mcp.go        # Prometheus/Victoria Metrics client
+├── diagnose_mcp.go          # clickhouse_diagnose tool + analyst connection
+├── bedrock.go               # Bedrock Converse tool-use loop (IRSA credentials)
 ├── clickhouse.go            # ClickHouse connection (analysis mode)
 ├── agent.go                 # Gemini AI integration (analysis mode)
 ├── slack.go                 # Slack notifications (analysis mode)
 ├── config.go                # Config loading and logging setup
+├── *_test.go                # Table-driven tests (SQL validator, query building, prometheus)
 ├── Dockerfile               # Multi-stage build → distroless runtime
 ├── docker-compose.yml       # Local ClickHouse for development
-├── chart/                   # Helm chart for Kubernetes
 └── configs/
     └── config.yml.sample    # Configuration template
 ```
+
+PostHog's Kubernetes deployment config (Helm chart, ArgoCD, IRSA) lives in private internal repos; the server itself is fully configurable via flags or a config file as shown above.
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Example requests:
 Same PromQL interface as `prometheus_query`, but targets a separate endpoint dedicated to ClickHouse-internal metrics (`ClickHouseMetrics_*`, `ClickHouseProfileEvents_*`, `ClickHouseAsyncMetrics_*`). Only registered when `prometheus_clickhouse.host` is set in config (see [Configuration](#️-configuration)). Use `prometheus_query` for general fleet/host metrics and `prometheus_query_clickhouse` for ClickHouse server internals.
 
 ### `clickhouse_diagnose` (optional)
-Ask a natural-language question ("why is X slow", "what's driving load") and a server-side Bedrock agent investigates via a guarded `run_sql` tool on a separate, elevated ClickHouse connection, returning only an attributed summary. Registered when `bedrock.region` + `bedrock.model_id` are set; credentials come from the default AWS chain (in-cluster: IRSA). Bounded by `bedrock.max_iterations` / `bedrock.max_seconds` — make sure your MCP client's tool timeout exceeds the latter. See [MCP.md](./MCP.md) for details.
+Ask a natural-language question ("why is X slow", "what's driving load") and a server-side Bedrock agent investigates via a guarded `run_sql` tool on a separate, elevated ClickHouse connection, returning only an attributed summary. Registered when `bedrock.region` + `bedrock.model_id` are set; credentials come from the default AWS chain. Bounded by `bedrock.max_iterations` / `bedrock.max_seconds` — make sure your MCP client's tool timeout exceeds the latter. See [MCP.md](./MCP.md) for details.
 
 ---
 
@@ -240,8 +240,6 @@ clickhouse:
 └── configs/
     └── config.yml.sample    # Configuration template
 ```
-
-PostHog's Kubernetes deployment config (Helm chart, ArgoCD, IRSA) lives in private internal repos; the server itself is fully configurable via flags or a config file as shown above.
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
## Summary

Repo docs were out of date with the current MCP server implementation — stale file references, missing tools, and contradictory query guidance.

## Changes

Rewrite CLAUDE.md and AGENTS.md with the actual file map (sdk_mcp.go, clickhouse_mcp.go, diagnose_mcp.go, bedrock.go, …), the full tool set, config keys (mcp.*, bedrock.*, analyst_clickhouse.*), and existing test locations
MCP.md: correct per-table clusterAllReplicas guidance (replicated → direct, sharded/system → wrap); document clickhouse_diagnose (args, iteration/wall-clock budgets, client tool-timeout requirement)
README.md: add clickhouse_diagnose to the tools list; fix the project-structure listing (add diagnose/bedrock/test files, remove nonexistent chart/ dir)
Mark the Gemini --analyze mode as legacy throughout

## Testing

Docs-only; every file, tool, and config reference cross-checked against current source
Deployment specifics kept generic (no internal repo names/paths/environments)