### PR TITLE
fix(bedrock): make temperature opt-in — Sonnet 5 rejects the paramete…

### DIFF
--- a/bedrock.go
+++ b/bedrock.go
@@ -81,16 +81,20 @@ func runBedrockAgent(
 	if maxSeconds > 0 {
 		deadline = time.Now().Add(time.Duration(maxSeconds) * time.Second)
 	}
+	// temperature < 0 means "don't send" — newer Anthropic models (Sonnet 5+)
+	// reject the temperature parameter on Converse entirely, so it's opt-in for
+	// the older models that still accept it.
+	infCfg := &types.InferenceConfiguration{MaxTokens: aws.Int32(maxTokens)}
+	if temperature >= 0 {
+		infCfg.Temperature = aws.Float32(temperature)
+	}
 	timedOut := false
 	for i := int32(0); i < maxIterations; i++ {
 		convInput := &bedrockruntime.ConverseInput{
-			ModelId:  aws.String(modelID),
-			System:   []types.SystemContentBlock{&types.SystemContentBlockMemberText{Value: system}},
-			Messages: messages,
-			InferenceConfig: &types.InferenceConfiguration{
-				MaxTokens:   aws.Int32(maxTokens),
-				Temperature: aws.Float32(temperature),
-			},
+			ModelId:         aws.String(modelID),
+			System:          []types.SystemContentBlock{&types.SystemContentBlockMemberText{Value: system}},
+			Messages:        messages,
+			InferenceConfig: infCfg,
 		}
 		// ToolConfig must always be set — Bedrock rejects a request whose history
 		// contains tool blocks if it's omitted. When the wall-clock budget is

--- a/config.go
+++ b/config.go
@@ -13,7 +13,8 @@ import (
 // searches several conventional locations to work when launched by external hosts (e.g., MCP clients).
 // Priority (highest to lowest): CLI flags > env vars > config file > defaults.
 // Env vars use the prefix HOUSEKEEPER_ with dots replaced by underscores, e.g.:
-//   HOUSEKEEPER_CLICKHOUSE_HOST, HOUSEKEEPER_CLICKHOUSE_PASSWORD, HOUSEKEEPER_HTTP_AUTH_TOKEN
+//
+//	HOUSEKEEPER_CLICKHOUSE_HOST, HOUSEKEEPER_CLICKHOUSE_PASSWORD, HOUSEKEEPER_HTTP_AUTH_TOKEN
 func loadConfig(explicitPath string) error {
 	// Enable environment variable support
 	viper.SetEnvPrefix("HOUSEKEEPER")
@@ -28,7 +29,7 @@ func loadConfig(explicitPath string) error {
 	viper.SetDefault("clickhouse.password", "")
 	viper.SetDefault("clickhouse.database", "default")
 	viper.SetDefault("clickhouse.cluster", "default")
-	
+
 	viper.SetDefault("prometheus.host", "localhost")
 	viper.SetDefault("prometheus.port", 8481)
 	viper.SetDefault("prometheus.vm_cluster_mode", false)
@@ -41,7 +42,7 @@ func loadConfig(explicitPath string) error {
 	viper.SetDefault("prometheus_clickhouse.vm_cluster_mode", false)
 	viper.SetDefault("prometheus_clickhouse.vm_tenant_id", "0")
 	viper.SetDefault("prometheus_clickhouse.vm_path_prefix", "")
-	
+
 	viper.SetDefault("logging.level", "info")
 	viper.SetDefault("logging.format", "text")
 
@@ -67,7 +68,9 @@ func loadConfig(explicitPath string) error {
 	// Wall-clock budget for a diagnosis; once exceeded the agent stops calling
 	// tools and returns a summary so the MCP client doesn't time out. 0 disables.
 	viper.SetDefault("bedrock.max_seconds", 25)
-	viper.SetDefault("bedrock.temperature", 0.2)
+	// < 0 = don't send temperature. Newer Anthropic models (Sonnet 5+) reject
+	// the parameter on Converse; set >= 0 only for older models that accept it.
+	viper.SetDefault("bedrock.temperature", -1)
 
 	// Optional separate ClickHouse connection used only by the server-side
 	// diagnose agent. Empty fields fall back to the clickhouse.* connection.
@@ -134,7 +137,7 @@ func configureLogging() {
 	if level == "" {
 		level = "info"
 	}
-	
+
 	parsedLevel, err := logrus.ParseLevel(strings.ToLower(level))
 	if err != nil {
 		logrus.WithError(err).Warn("Invalid log level, defaulting to info")

--- a/configs/config.yml.sample
+++ b/configs/config.yml.sample
@@ -60,7 +60,7 @@ bedrock:
   max_tokens: 2048
   max_iterations: 8      # max run_sql round-trips per diagnosis
   max_seconds: 25        # wall-clock budget; on exceed, summarize instead of timing out (0 = off)
-  temperature: 0.2
+  temperature: -1        # < 0 = don't send. Sonnet 5+ rejects the parameter; set >= 0 only for older models
 
 # Optional separate ClickHouse connection used only by the diagnose agent.
 # Leave user empty to fall back to the clickhouse.* connection above.


### PR DESCRIPTION
…r on Converse

## Summary

Sonnet 5 on Bedrock rejects the `temperature` inference parameter, failing every diagnose call after the model bump. Temperature is now opt-in.

## Changes

- `bedrock.go`: only set `InferenceConfig.Temperature` when `bedrock.temperature >= 0`
- `config.go` / `config.yml.sample`: default `bedrock.temperature` to `-1` (omit)

## Testing

- Reproduced live: `ValidationException: temperature is deprecated for this model` on diagnose calls
- gofmt clean; `go test ./...` via CI
- Post-deploy: one diagnose call per env