### PR TITLE
feat(diagnose): per-call budget_seconds arg with 50s default, clamped…

### DIFF
--- a/config.go
+++ b/config.go
@@ -65,9 +65,13 @@ func loadConfig(explicitPath string) error {
 	viper.SetDefault("bedrock.model_id", "")
 	viper.SetDefault("bedrock.max_tokens", 2048)
 	viper.SetDefault("bedrock.max_iterations", 8)
-	// Wall-clock budget for a diagnosis; once exceeded the agent stops calling
+	// Wall-clock CAP for a diagnosis; once exceeded the agent stops calling
 	// tools and returns a summary so the MCP client doesn't time out. 0 disables.
 	viper.SetDefault("bedrock.max_seconds", 25)
+	// Default per-call budget when the caller doesn't pass budget_seconds.
+	// Sized to fit clients with fixed ~60s tool timeouts; callers with larger
+	// timeouts opt up per call, clamped to max_seconds.
+	viper.SetDefault("bedrock.default_seconds", 50)
 	// < 0 = don't send temperature. Newer Anthropic models (Sonnet 5+) reject
 	// the parameter on Converse; set >= 0 only for older models that accept it.
 	viper.SetDefault("bedrock.temperature", -1)

--- a/configs/config.yml.sample
+++ b/configs/config.yml.sample
@@ -59,7 +59,8 @@ bedrock:
   model_id: ""           # Bedrock model or inference-profile id (set per deployment)
   max_tokens: 2048
   max_iterations: 8      # max run_sql round-trips per diagnosis
-  max_seconds: 25        # wall-clock budget; on exceed, summarize instead of timing out (0 = off)
+  max_seconds: 25        # wall-clock CAP per diagnosis; on exceed, summarize instead of timing out (0 = off)
+  default_seconds: 50    # per-call budget when the caller omits budget_seconds (clamped to max_seconds)
   temperature: -1        # < 0 = don't send. Sonnet 5+ rejects the parameter; set >= 0 only for older models
 
 # Optional separate ClickHouse connection used only by the diagnose agent.

--- a/diagnose_mcp.go
+++ b/diagnose_mcp.go
@@ -19,11 +19,44 @@ import (
 type diagnoseArgs struct {
 	Question string `json:"question"`
 	Cluster  string `json:"cluster,omitempty"`
+	// BudgetSeconds is the caller's wall-clock budget for this investigation.
+	// 0 = the deployment default (bedrock.default_seconds). Clamped to the
+	// deployment cap (bedrock.max_seconds). Callers should only raise this
+	// past ~50s when their MCP client tool timeout exceeds the budget.
+	BudgetSeconds int `json:"budget_seconds,omitempty"`
 }
 
 // maxToolResultChars caps how much row data a single run_sql result feeds back
 // to the model, bounding context size and tool-result payloads.
 const maxToolResultChars = 12000
+
+// capBudgetSeconds is the deployment ceiling for a single diagnosis
+// (bedrock.max_seconds). 0 disables the wall-clock budget entirely.
+func capBudgetSeconds() int {
+	return viper.GetInt("bedrock.max_seconds")
+}
+
+// defaultBudgetSeconds is the budget used when the caller doesn't pass
+// budget_seconds. Clamped to the cap.
+func defaultBudgetSeconds() int {
+	d := viper.GetInt("bedrock.default_seconds")
+	if c := capBudgetSeconds(); c > 0 && (d <= 0 || d > c) {
+		return c
+	}
+	return d
+}
+
+// resolveBudgetSeconds picks the effective wall-clock budget for one call:
+// the caller's budget_seconds when set (clamped to the cap), else the default.
+func resolveBudgetSeconds(requested int) int {
+	if requested <= 0 {
+		return defaultBudgetSeconds()
+	}
+	if c := capBudgetSeconds(); c > 0 && requested > c {
+		return c
+	}
+	return requested
+}
 
 // connectAnalyst opens the ClickHouse connection used by the diagnose agent. It
 // uses analyst_clickhouse.* config, falling back to the clickhouse.* connection
@@ -162,7 +195,10 @@ func registerDiagnoseTool(srv *mcp.Server) {
 		system += "\n\nDeployment-specific context:\n" + extra
 	}
 
-	desc := `Ask a natural-language question about ClickHouse health and get an investigated, attributed diagnosis. Runs an in-account LLM agent that investigates server-side and returns only a summary. Use for "why is X slow / lagging / erroring", "what's driving load on <cluster>", "who owns this query pattern". For raw row access use clickhouse_query instead.`
+	desc := `Ask a natural-language question about ClickHouse health and get an investigated, attributed diagnosis. Runs an in-account LLM agent that investigates server-side and returns only a summary. Use for "why is X slow / lagging / erroring", "what's driving load on <cluster>", "who owns this query pattern". For raw row access use clickhouse_query instead.
+
+budget_seconds: wall-clock budget for the investigation (default %d, cap %d). The default fits clients with a fixed ~60s tool timeout; pass a higher value up to the cap ONLY if your client's tool timeout exceeds it (e.g. MCP_TOOL_TIMEOUT in Claude Code) — otherwise the client gives up while the server keeps investigating. When the budget runs out the agent stops querying and summarizes findings so far; scope the question tightly for faster, deeper answers.`
+	desc = fmt.Sprintf(desc, defaultBudgetSeconds(), capBudgetSeconds())
 
 	mcp.AddTool[diagnoseArgs, map[string]any](
 		srv,
@@ -232,6 +268,11 @@ func registerDiagnoseTool(srv *mcp.Server) {
 				userMsg = fmt.Sprintf("%s\n\n(focus cluster: %s)", q, c)
 			}
 
+			budget := resolveBudgetSeconds(req.Arguments.BudgetSeconds)
+			logrus.WithFields(logrus.Fields{
+				"budget_seconds": budget, "requested": req.Arguments.BudgetSeconds,
+			}).Debug("diagnose: budget resolved")
+
 			answer, err := runBedrockAgent(
 				ctx, client,
 				viper.GetString("bedrock.model_id"),
@@ -239,7 +280,7 @@ func registerDiagnoseTool(srv *mcp.Server) {
 				[]bedrockTool{runSQL}, handle,
 				int32(viper.GetInt("bedrock.max_tokens")),
 				int32(viper.GetInt("bedrock.max_iterations")),
-				int32(viper.GetInt("bedrock.max_seconds")),
+				int32(budget),
 				float32(viper.GetFloat64("bedrock.temperature")),
 			)
 			if err != nil {


### PR DESCRIPTION
… to max_seconds

## Summary

Sonnet 5's higher per-turn latency pushes unguided diagnoses past the fixed ~60s tool timeout of common MCP clients, wasting the full investigation. The wall-clock budget is now per-call.

## Changes

- Add `budget_seconds` to diagnose tool args: 0/omitted = `bedrock.default_seconds` (new, default 50), always clamped to `bedrock.max_seconds` (now the cap)
- Document the arg + timeout guidance in the tool description
- `config.yml.sample`: document `default_seconds`

## Testing

- gofmt clean; go test ./... via CI
- Post-deploy: unguided diagnose from a 60s-timeout client should complete (~50s budget + summarize turn); `budget_seconds: 90` from Claude Code with raised MCP_TOOL_TIMEOUT gets the full window