### PR TITLE
fix(diagnose): refuse tool execution once over budget; drop default b…

### DIFF
--- a/bedrock.go
+++ b/bedrock.go
@@ -98,9 +98,8 @@ func runBedrockAgent(
 		}
 		// ToolConfig must always be set — Bedrock rejects a request whose history
 		// contains tool blocks if it's omitted. When the wall-clock budget is
-		// exceeded we instead nudge the model (below) to stop and summarize.
+		// exceeded we instead refuse tool execution (below) so the model summarizes.
 		convInput.ToolConfig = toolCfg
-		overBudget := maxSeconds > 0 && !time.Now().Before(deadline)
 		out, err := client.Converse(ctx, convInput)
 		if err != nil {
 			return "", fmt.Errorf("bedrock converse: %w", err)
@@ -131,7 +130,13 @@ func runBedrockAgent(
 		}
 		messages = append(messages, echo)
 
-		// Collect any text and any tool-use requests from this turn.
+		// Collect any text and any tool-use requests from this turn. The budget is
+		// re-checked HERE, after the turn returns, so a deadline that expired while
+		// the model was generating (or while earlier tools ran) refuses the newly
+		// requested tools instead of executing them — the previous shape executed
+		// one more full round of tools and only nudged afterwards, overshooting the
+		// budget by up to two model turns plus their queries.
+		overBudget := maxSeconds > 0 && !time.Now().Before(deadline)
 		var toolResults []types.ContentBlock
 		for _, block := range assistant.Content {
 			switch b := block.(type) {
@@ -139,6 +144,18 @@ func runBedrockAgent(
 				finalText = b.Value
 			case *types.ContentBlockMemberToolUse:
 				tu := b.Value
+				trb := types.ToolResultBlock{ToolUseId: tu.ToolUseId}
+				if overBudget {
+					// Refuse execution: every pending call gets a budget error so
+					// the model's only productive next move is the final summary.
+					timedOut = true
+					trb.Status = types.ToolResultStatusError
+					trb.Content = []types.ToolResultContentBlock{
+						&types.ToolResultContentBlockMemberText{Value: "error: time budget exceeded — do not call any more tools; give your final summary of findings now."},
+					}
+					toolResults = append(toolResults, &types.ContentBlockMemberToolResult{Value: trb})
+					continue
+				}
 				name := aws.ToString(tu.Name)
 				var input map[string]any
 				if tu.Input != nil {
@@ -148,7 +165,6 @@ func runBedrockAgent(
 				}
 				logrus.WithFields(logrus.Fields{"tool": name, "iter": i}).Debug("diagnose: tool call")
 				result, herr := handle(name, input)
-				trb := types.ToolResultBlock{ToolUseId: tu.ToolUseId}
 				if herr != nil {
 					trb.Status = types.ToolResultStatusError
 					trb.Content = []types.ToolResultContentBlock{
@@ -174,11 +190,11 @@ func runBedrockAgent(
 			return finalText, nil
 		}
 
-		// Feed tool results back. If we're over the time budget, append a nudge so
-		// the model stops investigating and summarizes on its next turn (tools stay
-		// available — we can't withhold them once history has tool blocks).
+		// Feed tool results back. Over budget, the results themselves are budget
+		// errors (above); the extra text block reinforces the stop instruction
+		// (tools stay schema-available — Bedrock requires ToolConfig once history
+		// has tool blocks).
 		if overBudget {
-			timedOut = true
 			toolResults = append(toolResults, &types.ContentBlockMemberText{
 				Value: "Time budget reached — do not call any more tools; give your final summary of findings now.",
 			})

--- a/config.go
+++ b/config.go
@@ -69,9 +69,10 @@ func loadConfig(explicitPath string) error {
 	// tools and returns a summary so the MCP client doesn't time out. 0 disables.
 	viper.SetDefault("bedrock.max_seconds", 25)
 	// Default per-call budget when the caller doesn't pass budget_seconds.
-	// Sized to fit clients with fixed ~60s tool timeouts; callers with larger
-	// timeouts opt up per call, clamped to max_seconds.
-	viper.SetDefault("bedrock.default_seconds", 50)
+	// Sized so budget + the in-flight turn + one summarize turn fits a fixed
+	// ~60s client tool timeout at Sonnet-5-class per-turn latency; callers with
+	// larger timeouts opt up per call, clamped to max_seconds.
+	viper.SetDefault("bedrock.default_seconds", 35)
 	// < 0 = don't send temperature. Newer Anthropic models (Sonnet 5+) reject
 	// the parameter on Converse; set >= 0 only for older models that accept it.
 	viper.SetDefault("bedrock.temperature", -1)

--- a/configs/config.yml.sample
+++ b/configs/config.yml.sample
@@ -60,7 +60,7 @@ bedrock:
   max_tokens: 2048
   max_iterations: 8      # max run_sql round-trips per diagnosis
   max_seconds: 25        # wall-clock CAP per diagnosis; on exceed, summarize instead of timing out (0 = off)
-  default_seconds: 50    # per-call budget when the caller omits budget_seconds (clamped to max_seconds)
+  default_seconds: 35    # per-call budget when the caller omits budget_seconds (clamped to max_seconds)
   temperature: -1        # < 0 = don't send. Sonnet 5+ rejects the parameter; set >= 0 only for older models
 
 # Optional separate ClickHouse connection used only by the diagnose agent.


### PR DESCRIPTION
…udget to 35s

## Summary

The wall-clock budget was checked before each model turn but tools were still executed for the turn in flight, overshooting by up to two full turns plus their queries — at Sonnet 5 per-turn latency, a 20s budget ran past 60s.

## Changes

- Re-check the deadline after each Converse turn returns; when over budget, answer every pending tool call with a budget error instead of executing it, so the model's next turn is the summary
- `bedrock.default_seconds` 50 → 35 (budget + in-flight turn + summarize turn now fits fixed ~60s client timeouts)

## Testing

- gofmt clean; go test ./... via CI
- Measured live: budget_seconds=20 previously ran past the 60s client timeout
- Post-deploy: unguided diagnose (35s default) and budget_seconds=20 both complete under 60s; budget_seconds=90 still available for raised-timeout clients