### PR TITLE
feat(diagnose): emit MCP progress notifications per model turn

### DIFF
--- a/bedrock.go
+++ b/bedrock.go
@@ -44,6 +44,11 @@ type bedrockTool struct {
 // not returned to the caller — only a fatal transport error aborts the loop.
 type toolHandler func(name string, input map[string]any) (string, error)
 
+// progressFunc reports investigation progress (iteration counter + message).
+// Nil disables reporting. Used to emit MCP progress notifications so
+// spec-compliant clients reset their tool timeout during long investigations.
+type progressFunc func(iteration int32, message string)
+
 // runBedrockAgent drives a Converse tool-use loop until the model produces a
 // final answer or a limit is hit (iteration count or wall-clock budget). When
 // the time budget is exceeded it makes one final tool-free turn so the model
@@ -56,6 +61,7 @@ func runBedrockAgent(
 	handle toolHandler,
 	maxTokens, maxIterations, maxSeconds int32,
 	temperature float32,
+	progress progressFunc,
 ) (string, error) {
 	toolCfg := &types.ToolConfiguration{Tools: make([]types.Tool, 0, len(tools))}
 	for _, t := range tools {
@@ -90,6 +96,11 @@ func runBedrockAgent(
 	}
 	timedOut := false
 	for i := int32(0); i < maxIterations; i++ {
+		// One tick per model turn (~15-40s apart) — frequent enough that a
+		// spec-compliant MCP client resets its tool timeout between turns.
+		if progress != nil {
+			progress(i+1, fmt.Sprintf("investigating: model turn %d/%d", i+1, maxIterations))
+		}
 		convInput := &bedrockruntime.ConverseInput{
 			ModelId:         aws.String(modelID),
 			System:          []types.SystemContentBlock{&types.SystemContentBlockMemberText{Value: system}},

--- a/diagnose_mcp.go
+++ b/diagnose_mcp.go
@@ -197,7 +197,7 @@ func registerDiagnoseTool(srv *mcp.Server) {
 
 	desc := `Ask a natural-language question about ClickHouse health and get an investigated, attributed diagnosis. Runs an in-account LLM agent that investigates server-side and returns only a summary. Use for "why is X slow / lagging / erroring", "what's driving load on <cluster>", "who owns this query pattern". For raw row access use clickhouse_query instead.
 
-budget_seconds: wall-clock budget for the investigation (default %d, cap %d). The default fits clients with a fixed ~60s tool timeout; pass a higher value up to the cap ONLY if your client's tool timeout exceeds it (e.g. MCP_TOOL_TIMEOUT in Claude Code) — otherwise the client gives up while the server keeps investigating. When the budget runs out the agent stops querying and summarizes findings so far; scope the question tightly for faster, deeper answers.`
+budget_seconds: wall-clock budget for the investigation (default %d, cap %d). The default fits clients with a fixed ~60s tool timeout; pass a higher value up to the cap ONLY if your client's tool timeout exceeds it (e.g. MCP_TOOL_TIMEOUT in Claude Code) — or if your client honors MCP progress notifications: the server emits one per model turn, and clients that reset their tool timeout on progress can run any budget up to the cap. When the budget runs out the agent stops querying and summarizes findings so far; scope the question tightly for faster, deeper answers.`
 	desc = fmt.Sprintf(desc, defaultBudgetSeconds(), capBudgetSeconds())
 
 	mcp.AddTool[diagnoseArgs, map[string]any](
@@ -273,6 +273,23 @@ budget_seconds: wall-clock budget for the investigation (default %d, cap %d). Th
 				"budget_seconds": budget, "requested": req.Arguments.BudgetSeconds,
 			}).Debug("diagnose: budget resolved")
 
+			// Emit MCP progress notifications (one per model turn) when the
+			// client supplied a progress token. Spec-compliant clients reset
+			// their tool timeout on each notification, which lets budgets
+			// beyond the client's fixed timeout actually complete.
+			var progress progressFunc
+			if token := req.GetProgressToken(); token != nil {
+				progress = func(iter int32, msg string) {
+					if perr := ss.NotifyProgress(ctx, &mcp.ProgressNotificationParams{
+						ProgressToken: token,
+						Progress:      float64(iter),
+						Message:       msg,
+					}); perr != nil {
+						logrus.WithError(perr).Debug("diagnose: progress notification failed")
+					}
+				}
+			}
+
 			answer, err := runBedrockAgent(
 				ctx, client,
 				viper.GetString("bedrock.model_id"),
@@ -282,6 +299,7 @@ budget_seconds: wall-clock budget for the investigation (default %d, cap %d). Th
 				int32(viper.GetInt("bedrock.max_iterations")),
 				int32(budget),
 				float32(viper.GetFloat64("bedrock.temperature")),
+				progress,
 			)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Summary

Long investigations die at fixed client tool timeouts (~60s) while the server keeps working. MCP progress notifications let spec-compliant clients reset their timeout each model turn, making budgets beyond the client's nominal timeout usable.

## Changes

- `runBedrockAgent` accepts an optional progress callback, invoked once per Converse turn with iteration count and message
- Diagnose handler forwards it to `ServerSession.NotifyProgress` when the request carries a progress token; no-op otherwise
- Document the progress path in the tool description

## Testing

- gofmt clean; go test ./... via CI
- Post-deploy litmus on dev: `budget_seconds: 120` from a fixed-60s client — completes if the client honors progress, times out at 60s as before if not