### PR TITLE
feat(diagnose): async investigation jobs. start/poll tool pair avoid

### DIFF
--- a/config.go
+++ b/config.go
@@ -73,6 +73,11 @@ func loadConfig(explicitPath string) error {
 	// ~60s client tool timeout at Sonnet-5-class per-turn latency; callers with
 	// larger timeouts opt up per call, clamped to max_seconds.
 	viper.SetDefault("bedrock.default_seconds", 35)
+	// Async jobs (clickhouse_diagnose_async): default budget when the caller
+	// doesn't pass budget_seconds (clamped to max_seconds), and how many
+	// investigations may run concurrently.
+	viper.SetDefault("bedrock.async_default_seconds", 120)
+	viper.SetDefault("bedrock.max_concurrent_jobs", 3)
 	// < 0 = don't send temperature. Newer Anthropic models (Sonnet 5+) reject
 	// the parameter on Converse; set >= 0 only for older models that accept it.
 	viper.SetDefault("bedrock.temperature", -1)

--- a/configs/config.yml.sample
+++ b/configs/config.yml.sample
@@ -61,6 +61,8 @@ bedrock:
   max_iterations: 8      # max run_sql round-trips per diagnosis
   max_seconds: 25        # wall-clock CAP per diagnosis; on exceed, summarize instead of timing out (0 = off)
   default_seconds: 35    # per-call budget when the caller omits budget_seconds (clamped to max_seconds)
+  async_default_seconds: 120  # default budget for clickhouse_diagnose_async jobs (clamped to max_seconds)
+  max_concurrent_jobs: 3      # concurrent async investigations allowed
   temperature: -1        # < 0 = don't send. Sonnet 5+ rejects the parameter; set >= 0 only for older models
 
 # Optional separate ClickHouse connection used only by the diagnose agent.

--- a/diagnose_async_mcp.go
+++ b/diagnose_async_mcp.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// Async diagnose: clickhouse_diagnose_async starts an investigation and
+// returns a job id immediately; clickhouse_diagnose_result polls it. This
+// sidesteps client tool timeouts entirely — the investigation runs server-side
+// regardless of whether the client waits — and stops wasting Bedrock work when
+// a client disconnects mid-run.
+//
+// The job store is in-memory and therefore single-instance: with multiple
+// server replicas, a poll can land on an instance that doesn't hold the job.
+// Adequate for single-replica deployments; add sticky routing or an external
+// store before scaling out.
+
+// finishedJobTTL is how long completed/failed jobs stay pollable.
+const finishedJobTTL = 30 * time.Minute
+
+// jobRunGrace is added to a job's budget for its context deadline, covering
+// the final summarize turn(s) after the budget itself is exhausted.
+const jobRunGrace = 90 * time.Second
+
+type diagnoseAsyncArgs struct {
+	Question string `json:"question"`
+	Cluster  string `json:"cluster,omitempty"`
+	// BudgetSeconds follows the same semantics as the synchronous tool but
+	// with a higher default (async callers aren't racing a client timeout).
+	// Clamped to bedrock.max_seconds.
+	BudgetSeconds int `json:"budget_seconds,omitempty"`
+}
+
+type diagnoseResultArgs struct {
+	JobID string `json:"job_id"`
+}
+
+type diagnoseJob struct {
+	ID        string
+	Question  string
+	Status    string // "running", "done", "error"
+	Answer    string
+	Err       string
+	Started   time.Time
+	Finished  time.Time
+	Iteration int32
+	Budget    int
+}
+
+type diagnoseJobStore struct {
+	mu   sync.Mutex
+	jobs map[string]*diagnoseJob
+}
+
+func newDiagnoseJobStore() *diagnoseJobStore {
+	return &diagnoseJobStore{jobs: map[string]*diagnoseJob{}}
+}
+
+// purgeLocked drops finished jobs past their TTL. Callers hold s.mu.
+func (s *diagnoseJobStore) purgeLocked() {
+	for id, j := range s.jobs {
+		if j.Status != "running" && time.Since(j.Finished) > finishedJobTTL {
+			delete(s.jobs, id)
+		}
+	}
+}
+
+func (s *diagnoseJobStore) runningCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, j := range s.jobs {
+		if j.Status == "running" {
+			n++
+		}
+	}
+	return n
+}
+
+func newJobID() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "dj_" + hex.EncodeToString(b), nil
+}
+
+// resolveAsyncBudgetSeconds picks the budget for an async job: the caller's
+// value clamped to the cap, defaulting to bedrock.async_default_seconds
+// (itself clamped) when unset.
+func resolveAsyncBudgetSeconds(requested int) int {
+	if requested <= 0 {
+		requested = viper.GetInt("bedrock.async_default_seconds")
+	}
+	if c := capBudgetSeconds(); c > 0 && (requested <= 0 || requested > c) {
+		return c
+	}
+	return requested
+}
+
+// registerDiagnoseAsyncTools adds the async start/poll tool pair. Registered
+// alongside the synchronous tool whenever Bedrock is configured.
+func registerDiagnoseAsyncTools(srv *mcp.Server) {
+	store := newDiagnoseJobStore()
+	maxConcurrent := viper.GetInt("bedrock.max_concurrent_jobs")
+
+	startDesc := fmt.Sprintf(`Start a ClickHouse investigation in the background and return a job id immediately — use this instead of clickhouse_diagnose when the investigation should run longer than your client's tool timeout. Same in-account agent and elevated access as clickhouse_diagnose; poll clickhouse_diagnose_result for the answer (a model turn takes ~15-40s, so poll every ~30s).
+
+budget_seconds: wall-clock budget (default %d, cap %d). Finished results stay pollable for %d minutes.`,
+		resolveAsyncBudgetSeconds(0), capBudgetSeconds(), int(finishedJobTTL.Minutes()))
+
+	mcp.AddTool[diagnoseAsyncArgs, map[string]any](
+		srv,
+		&mcp.Tool{
+			Name:        "clickhouse_diagnose_async",
+			Title:       "Start background ClickHouse diagnosis",
+			Description: startDesc,
+			Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+		},
+		func(ctx context.Context, ss *mcp.ServerSession, req *mcp.CallToolParamsFor[diagnoseAsyncArgs]) (*mcp.CallToolResultFor[map[string]any], error) {
+			q := strings.TrimSpace(req.Arguments.Question)
+			if q == "" {
+				return nil, fmt.Errorf("question is required")
+			}
+			if n := store.runningCount(); n >= maxConcurrent {
+				return nil, fmt.Errorf("%d investigations already running (max %d) — poll existing jobs or retry shortly", n, maxConcurrent)
+			}
+
+			id, err := newJobID()
+			if err != nil {
+				return nil, fmt.Errorf("generating job id: %w", err)
+			}
+			budget := resolveAsyncBudgetSeconds(req.Arguments.BudgetSeconds)
+			job := &diagnoseJob{
+				ID: id, Question: q, Status: "running",
+				Started: time.Now(), Budget: budget,
+			}
+			store.mu.Lock()
+			store.purgeLocked()
+			store.jobs[id] = job
+			store.mu.Unlock()
+
+			go runDiagnoseJob(store, job, q, req.Arguments.Cluster, budget)
+
+			logrus.WithFields(logrus.Fields{"job_id": id, "budget_seconds": budget}).Info("diagnose: async job started")
+			summary := fmt.Sprintf("started job %s (budget %ds) — poll clickhouse_diagnose_result with this job_id in ~30s", id, budget)
+			return &mcp.CallToolResultFor[map[string]any]{
+				Content: []mcp.Content{&mcp.TextContent{Text: summary}},
+				StructuredContent: map[string]any{
+					"job_id": id, "status": "running", "budget_seconds": budget,
+				},
+			}, nil
+		},
+	)
+
+	mcp.AddTool[diagnoseResultArgs, map[string]any](
+		srv,
+		&mcp.Tool{
+			Name:        "clickhouse_diagnose_result",
+			Title:       "Poll a background ClickHouse diagnosis",
+			Description: "Fetch the status/result of a clickhouse_diagnose_async job. Returns status running (with elapsed seconds and the agent's turn counter), done (with the answer), or error. Poll every ~30s while running.",
+			Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+		},
+		func(ctx context.Context, ss *mcp.ServerSession, req *mcp.CallToolParamsFor[diagnoseResultArgs]) (*mcp.CallToolResultFor[map[string]any], error) {
+			id := strings.TrimSpace(req.Arguments.JobID)
+			if id == "" {
+				return nil, fmt.Errorf("job_id is required")
+			}
+			store.mu.Lock()
+			store.purgeLocked()
+			job, ok := store.jobs[id]
+			var snapshot diagnoseJob
+			if ok {
+				snapshot = *job
+			}
+			store.mu.Unlock()
+			if !ok {
+				return nil, fmt.Errorf("unknown job %q (finished jobs expire after %d minutes)", id, int(finishedJobTTL.Minutes()))
+			}
+
+			data := map[string]any{
+				"job_id": snapshot.ID, "status": snapshot.Status,
+				"budget_seconds": snapshot.Budget,
+			}
+			var text string
+			switch snapshot.Status {
+			case "running":
+				elapsed := int(time.Since(snapshot.Started).Seconds())
+				data["elapsed_seconds"] = elapsed
+				data["model_turns"] = snapshot.Iteration
+				text = fmt.Sprintf("running: %ds elapsed of %ds budget, model turn %d — poll again in ~30s", elapsed, snapshot.Budget, snapshot.Iteration)
+			case "done":
+				data["answer"] = snapshot.Answer
+				data["elapsed_seconds"] = int(snapshot.Finished.Sub(snapshot.Started).Seconds())
+				text = snapshot.Answer
+			default: // error
+				data["error"] = snapshot.Err
+				text = "investigation failed: " + snapshot.Err
+			}
+			return &mcp.CallToolResultFor[map[string]any]{
+				Content:           []mcp.Content{&mcp.TextContent{Text: text}},
+				StructuredContent: data,
+			}, nil
+		},
+	)
+}
+
+// runDiagnoseJob executes one async investigation. It runs on its own
+// background context (the originating request has already returned) and
+// records the outcome on the job. A panic is contained to the job.
+func runDiagnoseJob(store *diagnoseJobStore, job *diagnoseJob, question, cluster string, budget int) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(budget)*time.Second+jobRunGrace)
+	defer cancel()
+
+	finish := func(status, answer, errMsg string) {
+		store.mu.Lock()
+		job.Status, job.Answer, job.Err = status, answer, errMsg
+		job.Finished = time.Now()
+		store.mu.Unlock()
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			logrus.WithField("job_id", job.ID).Errorf("diagnose: async job panic: %v", r)
+			finish("error", "", fmt.Sprintf("internal error: %v", r))
+		}
+	}()
+
+	progress := func(iter int32, _ string) {
+		store.mu.Lock()
+		job.Iteration = iter
+		store.mu.Unlock()
+	}
+
+	answer, err := runDiagnosis(ctx, question, cluster, budget, progress)
+	if err != nil {
+		logrus.WithError(err).WithField("job_id", job.ID).Warn("diagnose: async job failed")
+		finish("error", "", err.Error())
+		return
+	}
+	logrus.WithFields(logrus.Fields{
+		"job_id": job.ID, "elapsed": time.Since(job.Started).Seconds(),
+	}).Info("diagnose: async job complete")
+	finish("done", answer, "")
+}

--- a/diagnose_mcp.go
+++ b/diagnose_mcp.go
@@ -187,17 +187,99 @@ Output rules:
 
 Deployment-specific details (databases, tables, clusters, node sizes) are appended below when configured.`
 
-// registerDiagnoseTool adds the in-MCP, Bedrock-backed diagnose tool. The model
-// queries ClickHouse via the analyst connection and the tool returns its summary.
-func registerDiagnoseTool(srv *mcp.Server) {
+// diagnoseSystem assembles the diagnose agent's system prompt (base + the
+// shared deployment guidance).
+func diagnoseSystem() string {
 	system := diagnoseSystemPrompt
 	if extra := strings.TrimSpace(viper.GetString("mcp.extra_tool_description")); extra != "" {
 		system += "\n\nDeployment-specific context:\n" + extra
 	}
+	return system
+}
+
+// runDiagnosis performs one complete investigation: it opens the Bedrock
+// client and analyst connection, exposes the guarded run_sql tool, and drives
+// the agent loop until an answer or the budget. Shared by the synchronous
+// clickhouse_diagnose tool and the async job runner — ctx governs the whole
+// investigation, so the caller decides whether it is bound to a request or to
+// a background job.
+func runDiagnosis(ctx context.Context, question, cluster string, budgetSeconds int, progress progressFunc) (string, error) {
+	client, err := newBedrockClient(ctx)
+	if err != nil {
+		return "", err
+	}
+	conn, err := connectAnalyst()
+	if err != nil {
+		return "", fmt.Errorf("analyst connection: %w", err)
+	}
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			logrus.WithError(cerr).Warn("diagnose: error closing analyst connection")
+		}
+	}()
+
+	// The single tool the model may call: a guarded read-only query.
+	runSQL := bedrockTool{
+		name:        "run_sql",
+		description: "Execute one read-only SELECT/WITH query against ClickHouse and return the rows. Single statement only.",
+		inputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"sql": map[string]any{
+					"type":        "string",
+					"description": "A single read-only SELECT or WITH query. Use clusterAllReplicas('<cluster>', system.<table>) for system tables.",
+				},
+			},
+			"required": []any{"sql"},
+		},
+	}
+
+	handle := func(name string, input map[string]any) (string, error) {
+		if name != "run_sql" {
+			return "", fmt.Errorf("unknown tool %q", name)
+		}
+		sql, _ := input["sql"].(string)
+		sql = strings.TrimSpace(sql)
+		if sql == "" {
+			return "", fmt.Errorf("sql is empty")
+		}
+		if err := validateFreeformSQL(sql); err != nil {
+			return "", err
+		}
+		rows, err := queryRows(ctx, conn, sql)
+		if err != nil {
+			return "", err
+		}
+		return formatRowsForModel(rows), nil
+	}
+
+	userMsg := question
+	if c := strings.TrimSpace(cluster); c != "" {
+		userMsg = fmt.Sprintf("%s\n\n(focus cluster: %s)", question, c)
+	}
+
+	return runBedrockAgent(
+		ctx, client,
+		viper.GetString("bedrock.model_id"),
+		diagnoseSystem(), userMsg,
+		[]bedrockTool{runSQL}, handle,
+		int32(viper.GetInt("bedrock.max_tokens")),
+		int32(viper.GetInt("bedrock.max_iterations")),
+		int32(budgetSeconds),
+		float32(viper.GetFloat64("bedrock.temperature")),
+		progress,
+	)
+}
+
+// registerDiagnoseTool adds the in-MCP, Bedrock-backed diagnose tool. The model
+// queries ClickHouse via the analyst connection and the tool returns its summary.
+func registerDiagnoseTool(srv *mcp.Server) {
 
 	desc := `Ask a natural-language question about ClickHouse health and get an investigated, attributed diagnosis. Runs an in-account LLM agent that investigates server-side and returns only a summary. Use for "why is X slow / lagging / erroring", "what's driving load on <cluster>", "who owns this query pattern". For raw row access use clickhouse_query instead.
 
-budget_seconds: wall-clock budget for the investigation (default %d, cap %d). The default fits clients with a fixed ~60s tool timeout; pass a higher value up to the cap ONLY if your client's tool timeout exceeds it (e.g. MCP_TOOL_TIMEOUT in Claude Code) — or if your client honors MCP progress notifications: the server emits one per model turn, and clients that reset their tool timeout on progress can run any budget up to the cap. When the budget runs out the agent stops querying and summarizes findings so far; scope the question tightly for faster, deeper answers.`
+budget_seconds: wall-clock budget for the investigation (default %d, cap %d). The default fits clients with a fixed ~60s tool timeout; pass a higher value up to the cap ONLY if your client's tool timeout exceeds it (e.g. MCP_TOOL_TIMEOUT in Claude Code) — or if your client honors MCP progress notifications: the server emits one per model turn, and clients that reset their tool timeout on progress can run any budget up to the cap. When the budget runs out the agent stops querying and summarizes findings so far; scope the question tightly for faster, deeper answers.
+
+For investigations longer than your client can wait, use clickhouse_diagnose_async + clickhouse_diagnose_result instead.`
 	desc = fmt.Sprintf(desc, defaultBudgetSeconds(), capBudgetSeconds())
 
 	mcp.AddTool[diagnoseArgs, map[string]any](
@@ -212,60 +294,6 @@ budget_seconds: wall-clock budget for the investigation (default %d, cap %d). Th
 			q := strings.TrimSpace(req.Arguments.Question)
 			if q == "" {
 				return nil, fmt.Errorf("question is required")
-			}
-
-			client, err := newBedrockClient(ctx)
-			if err != nil {
-				return nil, err
-			}
-			conn, err := connectAnalyst()
-			if err != nil {
-				return nil, fmt.Errorf("analyst connection: %w", err)
-			}
-			defer func() {
-				if cerr := conn.Close(); cerr != nil {
-					logrus.WithError(cerr).Warn("diagnose: error closing analyst connection")
-				}
-			}()
-
-			// The single tool the model may call: a guarded read-only query.
-			runSQL := bedrockTool{
-				name:        "run_sql",
-				description: "Execute one read-only SELECT/WITH query against ClickHouse and return the rows. Single statement only.",
-				inputSchema: map[string]any{
-					"type": "object",
-					"properties": map[string]any{
-						"sql": map[string]any{
-							"type":        "string",
-							"description": "A single read-only SELECT or WITH query. Use clusterAllReplicas('<cluster>', system.<table>) for system tables.",
-						},
-					},
-					"required": []any{"sql"},
-				},
-			}
-
-			handle := func(name string, input map[string]any) (string, error) {
-				if name != "run_sql" {
-					return "", fmt.Errorf("unknown tool %q", name)
-				}
-				sql, _ := input["sql"].(string)
-				sql = strings.TrimSpace(sql)
-				if sql == "" {
-					return "", fmt.Errorf("sql is empty")
-				}
-				if err := validateFreeformSQL(sql); err != nil {
-					return "", err
-				}
-				rows, err := queryRows(ctx, conn, sql)
-				if err != nil {
-					return "", err
-				}
-				return formatRowsForModel(rows), nil
-			}
-
-			userMsg := q
-			if c := strings.TrimSpace(req.Arguments.Cluster); c != "" {
-				userMsg = fmt.Sprintf("%s\n\n(focus cluster: %s)", q, c)
 			}
 
 			budget := resolveBudgetSeconds(req.Arguments.BudgetSeconds)
@@ -290,17 +318,7 @@ budget_seconds: wall-clock budget for the investigation (default %d, cap %d). Th
 				}
 			}
 
-			answer, err := runBedrockAgent(
-				ctx, client,
-				viper.GetString("bedrock.model_id"),
-				system, userMsg,
-				[]bedrockTool{runSQL}, handle,
-				int32(viper.GetInt("bedrock.max_tokens")),
-				int32(viper.GetInt("bedrock.max_iterations")),
-				int32(budget),
-				float32(viper.GetFloat64("bedrock.temperature")),
-				progress,
-			)
+			answer, err := runDiagnosis(ctx, q, req.Arguments.Cluster, budget, progress)
 			if err != nil {
 				return nil, err
 			}

--- a/sdk_mcp.go
+++ b/sdk_mcp.go
@@ -102,7 +102,8 @@ step: Go duration ("15s", "30s", "1m"). 15s exploits the upstream's native resol
 	// with the analyst connection and returns only a summary.
 	if bedrockEnabled() {
 		registerDiagnoseTool(srv)
-		logrus.Info("diagnose tool enabled (Bedrock in-account analysis)")
+		registerDiagnoseAsyncTools(srv)
+		logrus.Info("diagnose tools enabled (Bedrock in-account analysis, sync + async)")
 	}
 
 	return runHTTPMCPServer(srv)


### PR DESCRIPTION
…client timeouts

## Summary

Fixed-timeout MCP clients (Claude Desktop, Cowork bridge: ~60s, progress notifications not honored) can't run deep investigations synchronously. Async jobs decouple the investigation from the client's wait: start returns a job id immediately, the agent runs server-side, and the result is polled.

## Changes

- New clickhouse_diagnose_async (question/cluster/budget_seconds → job_id; default budget 120s clamped to max_seconds; concurrency-capped) and clickhouse_diagnose_result (running with elapsed/turn counter, done with answer, error)
- Extract shared runDiagnosis() used by both sync and async paths; sync tool behavior unchanged
- Jobs run on a background context (budget + 90s grace), contain panics, and expire 30 minutes after finishing; in-memory store documented as single-replica
- New config: bedrock.async_default_seconds (120), bedrock.max_concurrent_jobs (3)

## Testing

- gofmt clean; go build/test locally + CI
- Post-deploy from a fixed-60s client: start a 120s job, poll ~30s apart, verify the full deep answer arrives — the exact scenario that times out synchronously today
- Verify concurrency cap rejects a 4th simultaneous start, and unknown/expired job ids error cleanly